### PR TITLE
Remove positive check on votes

### DIFF
--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -76,7 +76,7 @@ export function saveVotes(dbPool: PostgresJsDatabase<typeof db>) {
       .array(
         z.object({
           optionId: z.string(),
-          numOfVotes: z.number().positive(),
+          numOfVotes: z.number().min(0),
         }),
       )
       .safeParse(req.body);


### PR DESCRIPTION
## overview
with the positive check 0 was considered an invalid vote, but that prevents users from removing all votes from an option. With Min it will include 0 and not allow negative numbers