### PR TITLE
Filter question options for accepted options

### DIFF
--- a/src/services/cycles.ts
+++ b/src/services/cycles.ts
@@ -16,6 +16,15 @@ export function getActiveCycles(dbPool: PostgresJsDatabase<typeof db>) {
       },
     });
 
+    // Filter out the accepted question options from each forum question
+    activeCycles.forEach((cycle) => {
+      cycle.forumQuestions.forEach((forumQuestion) => {
+        forumQuestion.questionOptions = forumQuestion.questionOptions.filter(
+          (option) => option.accepted,
+        );
+      });
+    });
+
     return res.json({ data: activeCycles });
   };
 }
@@ -37,6 +46,14 @@ export function getEventCycles(dbPool: PostgresJsDatabase<typeof db>) {
           },
         },
       },
+    });
+
+    eventCycles.forEach((cycle) => {
+      cycle.forumQuestions.forEach((forumQuestion) => {
+        forumQuestion.questionOptions = forumQuestion.questionOptions.filter(
+          (option) => option.accepted,
+        );
+      });
     });
 
     return res.json({ data: eventCycles });
@@ -61,6 +78,14 @@ export function getCycleById(dbPool: PostgresJsDatabase<typeof db>) {
         },
       },
     });
+
+    if (cycle) {
+      cycle.forumQuestions.forEach((forumQuestion) => {
+        forumQuestion.questionOptions = forumQuestion.questionOptions.filter(
+          (option) => option.accepted,
+        );
+      });
+    }
 
     return res.json({ data: cycle });
   };

--- a/src/services/cycles.ts
+++ b/src/services/cycles.ts
@@ -10,19 +10,12 @@ export function getActiveCycles(dbPool: PostgresJsDatabase<typeof db>) {
       with: {
         forumQuestions: {
           with: {
-            questionOptions: true,
+            questionOptions: {
+              where: eq(db.questionOptions.accepted, true),
+            },
           },
         },
       },
-    });
-
-    // Filter out the accepted question options from each forum question
-    activeCycles.forEach((cycle) => {
-      cycle.forumQuestions.forEach((forumQuestion) => {
-        forumQuestion.questionOptions = forumQuestion.questionOptions.filter(
-          (option) => option.accepted,
-        );
-      });
     });
 
     return res.json({ data: activeCycles });
@@ -42,18 +35,12 @@ export function getEventCycles(dbPool: PostgresJsDatabase<typeof db>) {
       with: {
         forumQuestions: {
           with: {
-            questionOptions: true,
+            questionOptions: {
+              where: eq(db.questionOptions.accepted, true),
+            },
           },
         },
       },
-    });
-
-    eventCycles.forEach((cycle) => {
-      cycle.forumQuestions.forEach((forumQuestion) => {
-        forumQuestion.questionOptions = forumQuestion.questionOptions.filter(
-          (option) => option.accepted,
-        );
-      });
     });
 
     return res.json({ data: eventCycles });
@@ -73,19 +60,13 @@ export function getCycleById(dbPool: PostgresJsDatabase<typeof db>) {
       with: {
         forumQuestions: {
           with: {
-            questionOptions: true,
+            questionOptions: {
+              where: eq(db.questionOptions.accepted, true),
+            },
           },
         },
       },
     });
-
-    if (cycle) {
-      cycle.forumQuestions.forEach((forumQuestion) => {
-        forumQuestion.questionOptions = forumQuestion.questionOptions.filter(
-          (option) => option.accepted,
-        );
-      });
-    }
 
     return res.json({ data: cycle });
   };


### PR DESCRIPTION
Included filter for question options with the `accpted == true` flag in the cycles service. That way the frontend only receives relevant question options. 