### PR TITLE
Add statistics to results page 

### DIFF
--- a/src/services/resultsPage.ts
+++ b/src/services/resultsPage.ts
@@ -108,39 +108,44 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
             
             /* Query distinct groups and group names by option id */
             user_group_name AS (
-              SELECT users_to_groups."user_id", users_to_groups."group_id", groups."name" 
-              FROM users_to_groups
-              LEFT JOIN groups
-              ON users_to_groups."group_id" = groups."id"
+                SELECT users_to_groups."user_id", users_to_groups."group_id", groups."name" 
+                FROM users_to_groups
+                LEFT JOIN groups
+                ON users_to_groups."group_id" = groups."id"
             ),
             
             option_user AS (
-              SELECT option_id, user_id
-              FROM votes
-              WHERE question_id = '${forumQuestionId}'
-              GROUP BY option_id, user_id
+                SELECT option_id, user_id
+                FROM votes
+                WHERE question_id = '${forumQuestionId}'
+                GROUP BY option_id, user_id
             ),
             
             option_user_group_name AS (
-              SELECT option_user."user_id", option_user."option_id", 
-                user_group_name."group_id", user_group_name."name"
-              FROM option_user 
-              LEFT JOIN user_group_name 
-              ON option_user."user_id" = user_group_name."user_id"
+                SELECT option_user."user_id", option_user."option_id", 
+                  user_group_name."group_id", user_group_name."name"
+                FROM option_user 
+                LEFT JOIN user_group_name 
+                ON option_user."user_id" = user_group_name."user_id"
             ),
             
             option_distinct_group_name AS (
-              SELECT option_id AS "optionId", count(DISTINCT group_id) AS "distinctGroups", 
-              STRING_TO_ARRAY(STRING_AGG(DISTINCT name, ','), ',') AS "listOfGroupNames"
-              FROM option_user_group_name
-              GROUP BY option_id
+                SELECT option_id AS "optionId", count(DISTINCT group_id) AS "distinctGroups", 
+                STRING_TO_ARRAY(STRING_AGG(DISTINCT name, ','), ',') AS "listOfGroupNames"
+                FROM option_user_group_name
+                GROUP BY option_id
             ),
             
             /* Aggregated results */
             merged_result AS (
-                SELECT id_title_score."optionId", id_title_score."optionTitle", id_title_score."optionSubTitle",
-                    id_title_score."pluralityScore", distinct_users."distinctUsers",
-                    hearts."allocatedHearts", group_count_names."distinctGroups", group_count_names."listOfGroupNames" 
+                SELECT id_title_score."optionId", 
+                      id_title_score."optionTitle",
+                      id_title_score."optionSubTitle",
+                      id_title_score."pluralityScore",
+                      distinct_users."distinctUsers",
+                      hearts."allocatedHearts",
+                      group_count_names."distinctGroups",
+                      group_count_names."listOfGroupNames" 
                 FROM plural_score_and_title AS id_title_score
                 LEFT JOIN distinct_voters_by_option AS distinct_users 
                 ON id_title_score."optionId" = distinct_users."optionId"

--- a/src/services/resultsPage.ts
+++ b/src/services/resultsPage.ts
@@ -71,6 +71,7 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
         dbPool.execute<{
           optionId: string;
           optionTitle: string;
+          optionSubTitle: string;
           pluralityScore: number;
           distinctUsers: number;
           allocatedHearts: number;
@@ -84,7 +85,7 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
             ),
             
             plural_score_and_title AS (
-                SELECT "id" AS "optionId", "option_title" AS "optionTitle", vote_score AS "pluralityScore"
+                SELECT "id" AS "optionId", "option_title" AS "optionTitle", "option_sub_title" AS "optionSubTitle", vote_score AS "pluralityScore"
                 FROM question_options
                 WHERE question_id = '${forumQuestionId}'
             ),
@@ -102,7 +103,7 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
             ),
             
             merged_result AS (
-                SELECT id_title_score."optionId", id_title_score."optionTitle",
+                SELECT id_title_score."optionId", id_title_score."optionTitle", id_title_score."optionSubTitle",
                     id_title_score."pluralityScore", distinct_users."distinctUsers",
                     hearts."allocatedHearts"
                 FROM plural_score_and_title AS id_title_score
@@ -126,6 +127,7 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
         string,
         {
           optionTitle: string;
+          optionSubTitle: string;
           pluralityScore: number;
           distinctUsers: number;
           allocatedHearts: number;
@@ -137,6 +139,7 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
         const {
           optionId: indivOptionId,
           optionTitle: indivOptionTitle,
+          optionSubTitle: indivOptionSubTitle,
           pluralityScore: indivPluralityScore,
           distinctUsers: indivDistinctUsers,
           allocatedHearts: indivAllocatedHearts,
@@ -144,6 +147,7 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
 
         indivStats[indivOptionId] = {
           optionTitle: indivOptionTitle || 'No Title Provided',
+          optionSubTitle: indivOptionSubTitle || '',
           pluralityScore: indivPluralityScore || 0,
           distinctUsers: indivDistinctUsers || 0,
           allocatedHearts: indivAllocatedHearts || 0,

--- a/src/services/resultsPage.ts
+++ b/src/services/resultsPage.ts
@@ -3,11 +3,13 @@ import * as db from '../db';
 import type { Request, Response } from 'express';
 import { sql } from 'drizzle-orm';
 
+/**
+ * Retrieves aggregate statistics for the results page, including total number of proposals,
+ * total allocated hearts, number of participants, number of groups, and individual results.
+ * @param {PostgresJsDatabase<typeof db>} dbPool - The database connection pool.
+ * @returns {Promise<void>} A promise that resolves with the aggregated statistics JSON response.
+ */
 export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
-  // Retrieves aggregate statistics for the results page, including total number of proposals,
-  // total allocated hearts, number of participants, number of groups, and individual results.
-  // @param {PostgresJsDatabase<typeof db>} dbPool - The database connection pool.
-  // @returns {Promise<void>} - A promise that resolves with the aggregated statistics JSON response.
   return async function (req: Request, res: Response) {
     try {
       const forumQuestionId = req.params.forumQuestionId;

--- a/src/services/resultsPage.ts
+++ b/src/services/resultsPage.ts
@@ -28,6 +28,7 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
             SELECT count("id") AS "numProposals" 
             FROM question_options
             WHERE question_id = '${forumQuestionId}'
+            AND accepted = TRUE
           `),
         ),
 

--- a/src/services/resultsPage.ts
+++ b/src/services/resultsPage.ts
@@ -93,6 +93,7 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
                 SELECT "id" AS "optionId", "option_title" AS "optionTitle", "option_sub_title" AS "optionSubTitle", vote_score AS "pluralityScore"
                 FROM question_options
                 WHERE question_id = '${forumQuestionId}'
+                AND accepted = TRUE -- makes sure to only expose data of accepted options
             ),
             
             allocated_hearts AS (

--- a/src/services/resultsPage.ts
+++ b/src/services/resultsPage.ts
@@ -75,6 +75,8 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
           pluralityScore: number;
           distinctUsers: number;
           allocatedHearts: number;
+          distinctGroups: number;
+          listOfGroupNames: string[];
         }>(
           sql.raw(`
             WITH distinct_voters_by_option AS (
@@ -102,15 +104,48 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
                 GROUP BY option_id
             ),
             
+            /* Query distinct groups and group names by option id */
+            user_group_name AS (
+              SELECT users_to_groups."user_id", users_to_groups."group_id", groups."name" 
+              FROM users_to_groups
+              LEFT JOIN groups
+              ON users_to_groups."group_id" = groups."id"
+            ),
+            
+            option_user AS (
+              SELECT option_id, user_id
+              FROM votes
+              WHERE question_id = '${forumQuestionId}'
+              GROUP BY option_id, user_id
+            ),
+            
+            option_user_group_name AS (
+              SELECT option_user."user_id", option_user."option_id", 
+                user_group_name."group_id", user_group_name."name"
+              FROM option_user 
+              LEFT JOIN user_group_name 
+              ON option_user."user_id" = user_group_name."user_id"
+            ),
+            
+            option_distinct_group_name AS (
+              SELECT option_id AS "optionId", count(DISTINCT group_id) AS "distinctGroups", 
+              STRING_TO_ARRAY(STRING_AGG(DISTINCT name, ','), ',') AS "listOfGroupNames"
+              FROM option_user_group_name
+              GROUP BY option_id
+            ),
+            
+            /* Aggregated results */
             merged_result AS (
                 SELECT id_title_score."optionId", id_title_score."optionTitle", id_title_score."optionSubTitle",
                     id_title_score."pluralityScore", distinct_users."distinctUsers",
-                    hearts."allocatedHearts"
+                    hearts."allocatedHearts", group_count_names."distinctGroups", group_count_names."listOfGroupNames" 
                 FROM plural_score_and_title AS id_title_score
                 LEFT JOIN distinct_voters_by_option AS distinct_users 
                 ON id_title_score."optionId" = distinct_users."optionId"
                 LEFT JOIN allocated_hearts AS hearts 
                 ON id_title_score."optionId" = hearts."optionId"
+                LEFT JOIN option_distinct_group_name AS group_count_names
+                ON id_title_score."optionId" = group_count_names."optionId"
             )
 
             SELECT *
@@ -131,6 +166,8 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
           pluralityScore: number;
           distinctUsers: number;
           allocatedHearts: number;
+          distinctGroups: number;
+          listOfGroupNames: string[];
         }
       > = {};
 
@@ -143,6 +180,8 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
           pluralityScore: indivPluralityScore,
           distinctUsers: indivDistinctUsers,
           allocatedHearts: indivAllocatedHearts,
+          distinctGroups: indivdistinctGroups,
+          listOfGroupNames: indivlistOfGroupNames,
         } = row;
 
         indivStats[indivOptionId] = {
@@ -151,6 +190,8 @@ export function getResultStatistics(dbPool: PostgresJsDatabase<typeof db>) {
           pluralityScore: indivPluralityScore || 0,
           distinctUsers: indivDistinctUsers || 0,
           allocatedHearts: indivAllocatedHearts || 0,
+          distinctGroups: indivdistinctGroups || 0,
+          listOfGroupNames: indivlistOfGroupNames || [],
         };
       });
 


### PR DESCRIPTION
### Overview

This PR adds the following three new statistics to the `resultsPage` service:
-  subtitle of a `question_option` 
- distinct number of groups that voted for a `question_option` 
- distinct list of group names that voted for a `question_option`

Note that this PR includes some styling changes as well as a filter to only expose statistics for accepted options. 