### PR TITLE
Register title and subtitle

### DIFF
--- a/migrations/0009_misty_storm.sql
+++ b/migrations/0009_misty_storm.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "question_options" DROP CONSTRAINT "question_options_registration_data_id_registration_data_id_fk";
+--> statement-breakpoint
+ALTER TABLE "question_options" ADD COLUMN "registration_id" uuid;--> statement-breakpoint
+ALTER TABLE "registration_fields" ADD COLUMN "question_option_type" varchar;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "question_options" ADD CONSTRAINT "question_options_registration_id_registrations_id_fk" FOREIGN KEY ("registration_id") REFERENCES "registrations"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "question_options" DROP COLUMN IF EXISTS "registration_data_id";

--- a/migrations/0009_perfect_warbound.sql
+++ b/migrations/0009_perfect_warbound.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "question_options" RENAME COLUMN "registration_data_id" TO "registration_id";--> statement-breakpoint
+ALTER TABLE "question_options" DROP CONSTRAINT "question_options_registration_data_id_registration_data_id_fk";
+--> statement-breakpoint
+ALTER TABLE "registration_fields" ADD COLUMN "question_option_type" varchar;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "question_options" ADD CONSTRAINT "question_options_registration_id_registration_data_registration_id_fk" FOREIGN KEY ("registration_id") REFERENCES "registration_data"("registration_id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/migrations/0009_perfect_warbound.sql
+++ b/migrations/0009_perfect_warbound.sql
@@ -1,9 +1,0 @@
-ALTER TABLE "question_options" RENAME COLUMN "registration_data_id" TO "registration_id";--> statement-breakpoint
-ALTER TABLE "question_options" DROP CONSTRAINT "question_options_registration_data_id_registration_data_id_fk";
---> statement-breakpoint
-ALTER TABLE "registration_fields" ADD COLUMN "question_option_type" varchar;--> statement-breakpoint
-DO $$ BEGIN
- ALTER TABLE "question_options" ADD CONSTRAINT "question_options_registration_id_registration_data_registration_id_fk" FOREIGN KEY ("registration_id") REFERENCES "registration_data"("registration_id") ON DELETE no action ON UPDATE no action;
-EXCEPTION
- WHEN duplicate_object THEN null;
-END $$;

--- a/migrations/meta/0009_snapshot.json
+++ b/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1183 @@
+{
+  "id": "9f848291-7f1d-408e-9252-dda29b98cb52",
+  "prevId": "17c8b1f2-261d-4197-ae32-85eec68de8ee",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_option_id": {
+          "name": "question_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_question_option_id_question_options_id_fk": {
+          "name": "comments_question_option_id_question_options_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "cycles": {
+      "name": "cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UPCOMING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cycles_event_id_events_id_fk": {
+          "name": "cycles_event_id_events_id_fk",
+          "tableFrom": "cycles",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_description": {
+          "name": "registration_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_display_rank": {
+          "name": "event_display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "federated_credentials": {
+      "name": "federated_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federated_credentials_user_id_users_id_fk": {
+          "name": "federated_credentials_user_id_users_id_fk",
+          "tableFrom": "federated_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_subject_idx": {
+          "name": "provider_subject_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "subject"
+          ]
+        }
+      }
+    },
+    "forum_questions": {
+      "name": "forum_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cycle_id": {
+          "name": "cycle_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_title": {
+          "name": "question_title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_sub_title": {
+          "name": "question_sub_title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forum_questions_cycle_id_cycles_id_fk": {
+          "name": "forum_questions_cycle_id_cycles_id_fk",
+          "tableFrom": "forum_questions",
+          "tableTo": "cycles",
+          "columnsFrom": [
+            "cycle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_notification": {
+          "name": "email_notification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "registrations": {
+      "name": "registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'DRAFT'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registrations_user_id_users_id_fk": {
+          "name": "registrations_user_id_users_id_fk",
+          "tableFrom": "registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "registrations_event_id_events_id_fk": {
+          "name": "registrations_event_id_events_id_fk",
+          "tableFrom": "registrations",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "registration_field_options": {
+      "name": "registration_field_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "registration_field_id": {
+          "name": "registration_field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_field_options_registration_field_id_registration_fields_id_fk": {
+          "name": "registration_field_options_registration_field_id_registration_fields_id_fk",
+          "tableFrom": "registration_field_options",
+          "tableTo": "registration_fields",
+          "columnsFrom": [
+            "registration_field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_title": {
+          "name": "option_title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_sub_title": {
+          "name": "option_sub_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "vote_score": {
+          "name": "vote_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_registration_id_registration_data_registration_id_fk": {
+          "name": "question_options_registration_id_registration_data_registration_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "registration_data",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "registration_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_options_question_id_forum_questions_id_fk": {
+          "name": "question_options_question_id_forum_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "forum_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_of_votes": {
+          "name": "num_of_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_option_id_question_options_id_fk": {
+          "name": "votes_option_id_question_options_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_question_id_forum_questions_id_fk": {
+          "name": "votes_question_id_forum_questions_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "forum_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "registration_fields": {
+      "name": "registration_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'TEXT'"
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_option_type": {
+          "name": "question_option_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields_display_rank": {
+          "name": "fields_display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_limit": {
+          "name": "character_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_fields_event_id_events_id_fk": {
+          "name": "registration_fields_event_id_events_id_fk",
+          "tableFrom": "registration_fields",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "registration_fields_question_id_forum_questions_id_fk": {
+          "name": "registration_fields_question_id_forum_questions_id_fk",
+          "tableFrom": "registration_fields",
+          "tableTo": "forum_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "registration_data": {
+      "name": "registration_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_field_id": {
+          "name": "registration_field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_data_registration_id_registrations_id_fk": {
+          "name": "registration_data_registration_id_registrations_id_fk",
+          "tableFrom": "registration_data",
+          "tableTo": "registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "registration_data_registration_field_id_registration_fields_id_fk": {
+          "name": "registration_data_registration_field_id_registration_fields_id_fk",
+          "tableFrom": "registration_data",
+          "tableTo": "registration_fields",
+          "columnsFrom": [
+            "registration_field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users_to_groups": {
+      "name": "users_to_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_groups_user_id_users_id_fk": {
+          "name": "users_to_groups_user_id_users_id_fk",
+          "tableFrom": "users_to_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_groups_group_id_groups_id_fk": {
+          "name": "users_to_groups_group_id_groups_id_fk",
+          "tableFrom": "users_to_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "user_attributes": {
+      "name": "user_attributes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribute_key": {
+          "name": "attribute_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribute_value": {
+          "name": "attribute_value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_attributes_user_id_users_id_fk": {
+          "name": "user_attributes_user_id_users_id_fk",
+          "tableFrom": "user_attributes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "likes_user_id_users_id_fk": {
+          "name": "likes_user_id_users_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "likes_comment_id_comments_id_fk": {
+          "name": "likes_comment_id_comments_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0009_snapshot.json
+++ b/migrations/meta/0009_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "9f848291-7f1d-408e-9252-dda29b98cb52",
+  "id": "45f302e4-48f7-4b35-9342-5eb2cd0e95bd",
   "prevId": "17c8b1f2-261d-4197-ae32-85eec68de8ee",
   "version": "5",
   "dialect": "pg",
@@ -660,15 +660,15 @@
       },
       "indexes": {},
       "foreignKeys": {
-        "question_options_registration_id_registration_data_registration_id_fk": {
-          "name": "question_options_registration_id_registration_data_registration_id_fk",
+        "question_options_registration_id_registrations_id_fk": {
+          "name": "question_options_registration_id_registrations_id_fk",
           "tableFrom": "question_options",
-          "tableTo": "registration_data",
+          "tableTo": "registrations",
           "columnsFrom": [
             "registration_id"
           ],
           "columnsTo": [
-            "registration_id"
+            "id"
           ],
           "onDelete": "no action",
           "onUpdate": "no action"

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -68,8 +68,8 @@
     {
       "idx": 9,
       "version": "5",
-      "when": 1708941890045,
-      "tag": "0009_perfect_warbound",
+      "when": 1708944974732,
+      "tag": "0009_misty_storm",
       "breakpoints": true
     }
   ]

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1708437059939,
       "tag": "0008_heavy_the_hunter",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "5",
+      "when": 1708941890045,
+      "tag": "0009_perfect_warbound",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/questionOptions.ts
+++ b/src/db/questionOptions.ts
@@ -2,12 +2,12 @@ import { boolean, pgTable, timestamp, uuid, varchar, numeric } from 'drizzle-orm
 import { forumQuestions } from './forumQuestions';
 import { relations } from 'drizzle-orm';
 import { votes } from './votes';
-import { registrationData } from './registrationData';
+import { registrations } from './registrations';
 import { comments } from './comments';
 
 export const questionOptions = pgTable('question_options', {
   id: uuid('id').primaryKey().defaultRandom(),
-  registrationId: uuid('registration_id').references(() => registrationData.registrationId),
+  registrationId: uuid('registration_id').references(() => registrations.id),
   questionId: uuid('question_id')
     .references(() => forumQuestions.id)
     .notNull(),
@@ -24,9 +24,9 @@ export const questionOptionsRelations = relations(questionOptions, ({ one, many 
     fields: [questionOptions.questionId],
     references: [forumQuestions.id],
   }),
-  registrationData: one(registrationData, {
+  registrations: one(registrations, {
     fields: [questionOptions.registrationId],
-    references: [registrationData.registrationId],
+    references: [registrations.id],
   }),
   comment: many(comments),
   votes: many(votes),

--- a/src/db/questionOptions.ts
+++ b/src/db/questionOptions.ts
@@ -7,7 +7,7 @@ import { comments } from './comments';
 
 export const questionOptions = pgTable('question_options', {
   id: uuid('id').primaryKey().defaultRandom(),
-  registrationDataId: uuid('registration_data_id').references(() => registrationData.id),
+  registrationId: uuid('registration_id').references(() => registrationData.registrationId),
   questionId: uuid('question_id')
     .references(() => forumQuestions.id)
     .notNull(),
@@ -25,8 +25,8 @@ export const questionOptionsRelations = relations(questionOptions, ({ one, many 
     references: [forumQuestions.id],
   }),
   registrationData: one(registrationData, {
-    fields: [questionOptions.registrationDataId],
-    references: [registrationData.id],
+    fields: [questionOptions.registrationId],
+    references: [registrationData.registrationId],
   }),
   comment: many(comments),
   votes: many(votes),

--- a/src/db/registrationFields.ts
+++ b/src/db/registrationFields.ts
@@ -13,6 +13,8 @@ export const registrationFields = pgTable('registration_fields', {
   type: varchar('type').notNull().default('TEXT'),
   required: boolean('required').default(false),
   questionId: uuid('question_id').references(() => forumQuestions.id),
+  // CAN BE: NULL, TITLE, OR SUBTITLE
+  questionOptionType: varchar('question_option_type'),
   fieldDisplayRank: integer('fields_display_rank'),
   characterLimit: integer('character_limit').default(0),
   createdAt: timestamp('created_at').notNull().defaultNow(),

--- a/src/services/registrationData.ts
+++ b/src/services/registrationData.ts
@@ -170,10 +170,39 @@ export async function updateQuestionOptions(
 
     console.log('output', output);
 
+    const combinedOutput: {
+      [registrationId: string]: {
+        registrationId: string;
+        questionId: string;
+        values: {
+          [questionOptionType: string]: string;
+        };
+      };
+    } = {};
+
+    output.forEach((data) => {
+      if (data) {
+        const key = data.registrationId;
+        if (!combinedOutput[key]) {
+          combinedOutput[key] = {
+            registrationId: data.registrationId,
+            questionId: data.questionId,
+            values: {},
+          };
+        }
+
+        // Demand that combinedOutput[key] will always be defined
+        combinedOutput[key]!.values[data.questionOptionType] = data.value;
+      }
+    });
+
+    const outputArray = Object.values(combinedOutput);
+
+    console.log('Combined Output:', outputArray);
+
     // for each registrationFieldId update or insert question options
-    for (const data of output) {
+    for (const data of outputArray) {
       if (!data) {
-        // Skip null entries
         continue;
       }
       // Check whether a corresponding question option exists
@@ -188,8 +217,8 @@ export async function updateQuestionOptions(
           .set({
             registrationId: data?.registrationId || existingQuestionOption.registrationId,
             questionId: existingQuestionOption.questionId,
-            optionTitle: data?.value || existingQuestionOption.optionTitle,
-            optionSubTitle: data?.value || existingQuestionOption.optionSubTitle,
+            optionTitle: data?.values['TITLE'] || existingQuestionOption.optionTitle,
+            optionSubTitle: data?.values['SUBTITLE'] || existingQuestionOption.optionSubTitle,
             updatedAt: new Date(),
           })
           .where(eq(db.questionOptions.id, existingQuestionOption.id))
@@ -201,8 +230,8 @@ export async function updateQuestionOptions(
           .values({
             registrationId: data?.registrationId || '',
             questionId: data?.questionId || '',
-            optionTitle: data?.value || '',
-            optionSubTitle: data?.value || '',
+            optionTitle: data?.values['TITLE'] || '',
+            optionSubTitle: data?.values['SUBTITLE'] || '',
             createdAt: new Date(),
             updatedAt: new Date(),
           })

--- a/src/services/registrationData.ts
+++ b/src/services/registrationData.ts
@@ -173,7 +173,7 @@ function filterRegistrationData(
  * @param filteredRegistrationData - Filtered registration data.
  * @returns Combined registration data.
  */
-function mapToCombinedData(
+function transformRegistrationDataToCombinedFormat(
   filteredRegistrationData: {
     id: string;
     registrationFieldId: string;
@@ -214,7 +214,7 @@ function mapToCombinedData(
  * @param dbPool - The database pool instance.
  * @param combinedData - Combined registration data.
  */
-async function updateQuestionOptions(
+async function upsertQuestionOptions(
   dbPool: PostgresJsDatabase<typeof db>,
   combinedData: {
     registrationId: string;
@@ -263,7 +263,7 @@ async function updateQuestionOptions(
  * @param dbPool - The database pool instance.
  * @param registrationData - An array of registration data.
  */
-export async function updateQuestionOptionsMain(
+export async function upsertQuestionOptionsMain(
   dbPool: PostgresJsDatabase<typeof db>,
   registrationData:
     | {
@@ -285,9 +285,12 @@ export async function updateQuestionOptionsMain(
 
     const filteredRegistrationData = filterRegistrationData(registrationData, registrationFields);
 
-    const combinedData = mapToCombinedData(filteredRegistrationData, registrationFields);
+    const combinedData = transformRegistrationDataToCombinedFormat(
+      filteredRegistrationData,
+      registrationFields,
+    );
 
-    await updateQuestionOptions(dbPool, combinedData);
+    await upsertQuestionOptions(dbPool, combinedData);
   } catch (e) {
     console.error('Error updating or inserting question options:', e);
     throw e;

--- a/src/services/registrationData.ts
+++ b/src/services/registrationData.ts
@@ -267,7 +267,7 @@ async function upsertQuestionOptions(
  * @param dbPool - The database pool instance.
  * @param registrationData - An array of registration data.
  */
-export async function upsertQuestionOptionsMain(
+export async function upsertQuestionOptionFromRegistrationData(
   dbPool: PostgresJsDatabase<typeof db>,
   registrationData:
     | {

--- a/src/services/registrationData.ts
+++ b/src/services/registrationData.ts
@@ -162,8 +162,7 @@ export async function updateQuestionOptions(
         await dbPool
           .update(db.questionOptions)
           .set({
-            registrationId:
-              registrationDataForField?.id || existingQuestionOption.registrationId,
+            registrationId: registrationDataForField?.id || existingQuestionOption.registrationId,
             questionId: existingQuestionOption.questionId,
             optionTitle: registrationDataForField?.value || existingQuestionOption.optionTitle,
             updatedAt: new Date(),

--- a/src/services/registrations.ts
+++ b/src/services/registrations.ts
@@ -5,7 +5,7 @@ import { and } from 'drizzle-orm';
 import { z } from 'zod';
 import { insertRegistrationSchema } from '../types';
 import * as db from '../db';
-import { upsertRegistrationData, updateQuestionOptions } from './registrationData';
+import { upsertRegistrationData, updateQuestionOptionsMain } from './registrationData';
 
 export function saveRegistration(dbPool: PostgresJsDatabase<typeof db>) {
   return async function (req: Request, res: Response) {
@@ -95,7 +95,7 @@ export async function sendRegistrationData(
   });
 
   try {
-    await updateQuestionOptions(dbPool, updatedRegistrationData);
+    await updateQuestionOptionsMain(dbPool, updatedRegistrationData);
 
     const out = {
       ...newRegistration,

--- a/src/services/registrations.ts
+++ b/src/services/registrations.ts
@@ -5,7 +5,7 @@ import { and } from 'drizzle-orm';
 import { z } from 'zod';
 import { insertRegistrationSchema } from '../types';
 import * as db from '../db';
-import { upsertRegistrationData, updateQuestionOptionsMain } from './registrationData';
+import { upsertRegistrationData, upsertQuestionOptionsMain } from './registrationData';
 
 export function saveRegistration(dbPool: PostgresJsDatabase<typeof db>) {
   return async function (req: Request, res: Response) {
@@ -95,7 +95,7 @@ export async function sendRegistrationData(
   });
 
   try {
-    await updateQuestionOptionsMain(dbPool, updatedRegistrationData);
+    await upsertQuestionOptionsMain(dbPool, updatedRegistrationData);
 
     const out = {
       ...newRegistration,

--- a/src/services/registrations.ts
+++ b/src/services/registrations.ts
@@ -5,7 +5,10 @@ import { and } from 'drizzle-orm';
 import { z } from 'zod';
 import { insertRegistrationSchema } from '../types';
 import * as db from '../db';
-import { upsertRegistrationData, upsertQuestionOptionsMain } from './registrationData';
+import {
+  upsertRegistrationData,
+  upsertQuestionOptionFromRegistrationData,
+} from './registrationData';
 
 export function saveRegistration(dbPool: PostgresJsDatabase<typeof db>) {
   return async function (req: Request, res: Response) {
@@ -95,7 +98,7 @@ export async function sendRegistrationData(
   });
 
   try {
-    await upsertQuestionOptionsMain(dbPool, updatedRegistrationData);
+    await upsertQuestionOptionFromRegistrationData(dbPool, updatedRegistrationData);
 
     const out = {
       ...newRegistration,


### PR DESCRIPTION
### Overview 

This PR adds a `questionOptionType` column to the `registrationFields` data table, which allows to identify whether a registration field is a `TITLE` or `SUBTITLE`. Furthermore, the PR changes the reference field in the `questionOptions` table from the `registrationFieldId` to the `registrationId` as the registration id is the same for different registration fields belonging to the same user. Lastly, the PR updates and refactors the `updateQuestionOptions` function to allow for the automatic updating of title and subtitle information for the same question options. 

Note that the implemented functionality is targeted solely to the `berlin` usecase. This is a little bit of a drawback as multiple events and multiple question_ids might not work with the implemented changes. This required a more general setup beyond the berlin usecase.

### Details about the registration data service update 

This PR refactors the `updateQuestionOptions` function to implement the required functionality and improve code clarity. The main changes include:

- Created separate functions for fetching registration fields, filtering registration data, mapping to combined data, and updating/inserting question options. The original monolithic `updateQuestionOptions` function is refactored into smaller, more focused functions, each responsible for a specific task. This improves readability and maintainability by breaking down the complex logic into reusable components.
- **New Functions**: Two new functions, `filterRegistrationData` and `mapToCombinedData`, have been introduced to handle intermediate processing steps:
    - `filterRegistrationData`: Filters registration data based on the available registration fields. It takes an array of registration data and registration fields as input and returns filtered registration data that requires updating.
    - `mapToCombinedData`: Maps filtered registration data to a combined format suitable for updating/inserting question options. It takes filtered registration data and registration fields as input and returns combined registration data with values grouped by question option type.

### Testing
- Remember to test this locally as datatable changes have been made.

