### PR TITLE
Diego/fix comments query

### DIFF
--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -1,4 +1,4 @@
-import { eq, inArray } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { Request, Response } from 'express';
 import { insertCommentSchema } from '../types';


### PR DESCRIPTION
removes 500 error querying comments

error:
```
Error getting comments:  PostgresError: syntax error at or near ""users""
    at ErrorResponse (/Users/diegoalzate/Code/work/lexicon/pluraltools-backend/node_modules/.pnpm/postgres@3.4.3/node_modules/postgres/cjs/src/connection.js:790:26)
    at handle (/Users/diegoalzate/Code/work/lexicon/pluraltools-backend/node_modules/.pnpm/postgres@3.4.3/node_modules/postgres/cjs/src/connection.js:476:6)
    at Socket.data (/Users/diegoalzate/Code/work/lexicon/pluraltools-backend/node_modules/.pnpm/postgres@3.4.3/node_modules/postgres/cjs/src/connection.js:315:9)
    at Socket.emit (node:events:514:28)
    at addChunk (node:internal/streams/readable:545:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:495:3)
    at Readable.push (node:internal/streams/readable:375:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
  severity_local: 'ERROR',
  severity: 'ERROR',
  code: '42601',
  position: '68',
  file: 'scan.l',
  line: '1241',
  routine: 'scanner_yyerror'
}
```