### PR TITLE
Test coverage for registrationData

### DIFF
--- a/src/services/registrationData.spec.ts
+++ b/src/services/registrationData.spec.ts
@@ -1,0 +1,89 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import * as db from '../db';
+import { createDbPool } from '../utils/db/createDbPool';
+import { runMigrations } from '../utils/db/runMigrations';
+import { registrationDataSchema } from '../types';
+import { cleanup, seed } from '../utils/db/seed';
+import { z } from 'zod';
+import { upsertRegistrationData } from './registrationData';
+
+const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
+
+describe('service: registrationData', () => {
+  let dbPool: PostgresJsDatabase<typeof db>;
+  let dbConnection: postgres.Sql<NonNullable<unknown>>;
+  let registrationTestData: z.infer<typeof registrationDataSchema>;
+  let questionOption: db.QuestionOption | undefined;
+  let forumQuestion: db.ForumQuestion | undefined;
+  let registrationField: db.RegistrationField | undefined;
+  let user: db.User | undefined;
+
+  beforeAll(async () => {
+    const initDb = createDbPool(DB_CONNECTION_URL, { max: 1 });
+    await runMigrations(DB_CONNECTION_URL);
+    dbPool = initDb.dbPool;
+    dbConnection = initDb.connection;
+    // seed
+    const { users, questionOptions, forumQuestions, cycles, registrationFields } = await seed(dbPool);
+    // Insert registration fields for the user
+    questionOption = questionOptions[0];
+    forumQuestion = forumQuestions[0];
+    user = users[0];
+    registrationField = registrationFields[0];
+    registrationTestData = [{
+      registrationFieldId: registrationField?.id ?? "",
+      value: 'something',
+    }];
+
+    // Add additional data to the Db
+    await dbPool.insert(db.registrationData).values(registrationTestData);
+    await dbPool.insert(db.votes).values(otherUserTestData);
+  });
+
+  test('should return aggregated statistics when all queries return valid data', async () => {
+    const questionId = forumQuestion!.id;
+
+    // Call getResultStatistics with the required parameters
+    const result = await upsertRegistrationData(questionId, dbPool);
+
+    // Test aggregate result statistics
+    expect(result).toBeDefined();
+    expect(result.numProposals).toEqual(2);
+    expect(result.sumNumOfHearts).toEqual(4);
+    expect(result.numOfParticipants).toEqual(2);
+
+    // Test option stats
+    expect(result.optionStats).toBeDefined();
+    expect(Object.keys(result.optionStats)).toHaveLength(2);
+
+    for (const optionId in result.optionStats) {
+      const optionStat = result.optionStats[optionId];
+      expect(optionStat).toBeDefined();
+      expect(optionStat?.optionTitle).toBeDefined();
+      expect(optionStat?.optionSubTitle).toBeDefined();
+      expect(optionStat?.pluralityScore).toBeDefined();
+      expect(optionStat?.distinctUsers).toBeDefined();
+      expect(optionStat?.allocatedHearts).toBeDefined();
+      expect(optionStat?.distinctGroups).toBeDefined();
+      expect(optionStat?.listOfGroupNames).toBeDefined();
+
+      // Add assertions for distinct users and allocated hearts
+      if (optionId === questionOption?.id) {
+        // Assuming this option belongs to the user
+        expect(optionStat?.distinctUsers).toEqual(2);
+        expect(optionStat?.allocatedHearts).toEqual(4);
+        expect(optionStat?.distinctGroups).toEqual(1);
+        const listOfGroupNames = optionStat?.listOfGroupNames;
+        // Check if the array is not empty
+        expect(listOfGroupNames).toBeDefined();
+        expect(listOfGroupNames?.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await cleanup(dbPool);
+    await dbConnection.end();
+  });
+});

--- a/src/services/registrationData.spec.ts
+++ b/src/services/registrationData.spec.ts
@@ -18,6 +18,7 @@ describe('service: registrationData', () => {
   let forumQuestion: db.ForumQuestion | undefined;
   let registrationField: db.RegistrationField | undefined;
   let user: db.User | undefined;
+  let registration: db.Registration | undefined;
 
   beforeAll(async () => {
     const initDb = createDbPool(DB_CONNECTION_URL, { max: 1 });
@@ -25,7 +26,7 @@ describe('service: registrationData', () => {
     dbPool = initDb.dbPool;
     dbConnection = initDb.connection;
     // seed
-    const { users, questionOptions, forumQuestions, cycles, registrationFields } = await seed(dbPool);
+    const { users, questionOptions, forumQuestions, registrationFields } = await seed(dbPool);
     // Insert registration fields for the user
     questionOption = questionOptions[0];
     forumQuestion = forumQuestions[0];

--- a/src/services/registrationData.spec.ts
+++ b/src/services/registrationData.spec.ts
@@ -14,10 +14,7 @@ const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
 describe('service: registrationData', () => {
   let dbPool: PostgresJsDatabase<typeof db>;
   let dbConnection: postgres.Sql<NonNullable<unknown>>;
-  let questionOption: db.QuestionOption | undefined;
-  let forumQuestion: db.ForumQuestion | undefined;
   let registrationField: db.RegistrationField | undefined;
-  let user: db.User | undefined;
   let registration: db.Registration | undefined;
   let testRegistration: z.infer<typeof insertRegistrationSchema>;
 
@@ -27,12 +24,8 @@ describe('service: registrationData', () => {
     dbPool = initDb.dbPool;
     dbConnection = initDb.connection;
     // seed
-    const { events, users, questionOptions, forumQuestions, registrationFields } =
-      await seed(dbPool);
-    // Insert registration fields for the user
-    questionOption = questionOptions[0];
-    forumQuestion = forumQuestions[0];
-    user = users[0];
+    const { events, users, registrationFields } = await seed(dbPool);
+    // insert registration fields
     registrationField = registrationFields[0];
 
     testRegistration = {

--- a/src/services/registrationData.spec.ts
+++ b/src/services/registrationData.spec.ts
@@ -3,7 +3,6 @@ import postgres from 'postgres';
 import * as db from '../db';
 import { createDbPool } from '../utils/db/createDbPool';
 import { runMigrations } from '../utils/db/runMigrations';
-import { registrationDataSchema } from '../types';
 import { insertRegistrationSchema } from '../types';
 import { cleanup, seed } from '../utils/db/seed';
 import { z } from 'zod';
@@ -15,11 +14,11 @@ const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
 describe('service: registrationData', () => {
   let dbPool: PostgresJsDatabase<typeof db>;
   let dbConnection: postgres.Sql<NonNullable<unknown>>;
-  let registrationTestData: z.infer<typeof registrationDataSchema>;
   let questionOption: db.QuestionOption | undefined;
   let forumQuestion: db.ForumQuestion | undefined;
   let registrationField: db.RegistrationField | undefined;
   let user: db.User | undefined;
+  let registration: db.Registration | undefined;
   let testRegistration: z.infer<typeof insertRegistrationSchema>;
 
   beforeAll(async () => {
@@ -35,12 +34,6 @@ describe('service: registrationData', () => {
     forumQuestion = forumQuestions[0];
     user = users[0];
     registrationField = registrationFields[0];
-    registrationTestData = [
-      {
-        registrationFieldId: registrationField?.id ?? '',
-        value: 'something',
-      },
-    ];
 
     testRegistration = {
       userId: users[0]?.id ?? '',
@@ -55,10 +48,45 @@ describe('service: registrationData', () => {
     };
 
     // Add test registration data to the db
-    await sendRegistrationData(dbPool, testRegistration, testRegistration.userId);
+    registration = await sendRegistrationData(dbPool, testRegistration, testRegistration.userId);
   });
 
-  test('should return aggregated statistics when all queries return valid data', async () => {});
+  test('should update existing records', async () => {
+    // Call the function with registration ID and registration data to update
+    const registrationId = registration?.id ?? '';
+    const registrationFieldId = registrationField?.id ?? '';
+    const updatedValue = 'updated';
+
+    console.log('testRegistration', testRegistration);
+    const registrationTestData = [
+      {
+        registrationFieldId: registrationFieldId,
+        value: updatedValue,
+      },
+    ];
+
+    const updatedData = await upsertRegistrationData({
+      dbPool,
+      registrationId: registrationId,
+      registrationData: registrationTestData,
+    });
+    console.log('updatedData', updatedData);
+
+    // Assert that the updated data array is not empty
+    expect(updatedData).toBeDefined();
+    expect(updatedData).not.toBeNull();
+
+    if (updatedData) {
+      // Assert that the updated data has the correct structure
+      expect(updatedData.length).toBeGreaterThan(0);
+      expect(updatedData[0]).toHaveProperty('id');
+      expect(updatedData[0]).toHaveProperty('registrationId', registrationId);
+      expect(updatedData[0]).toHaveProperty('registrationFieldId', registrationFieldId);
+      expect(updatedData[0]).toHaveProperty('value', updatedValue);
+      expect(updatedData[0]).toHaveProperty('createdAt');
+      expect(updatedData[0]).toHaveProperty('updatedAt');
+    }
+  });
 
   afterAll(async () => {
     await cleanup(dbPool);

--- a/src/services/registrationData.spec.ts
+++ b/src/services/registrationData.spec.ts
@@ -88,6 +88,29 @@ describe('service: registrationData', () => {
     }
   });
 
+  test('should return null when an error occurs', async () => {
+    // Provide an invalid registration id to trigger the error
+    const registrationId = '';
+    const registrationFieldId = registrationField?.id ?? '';
+    const updatedValue = 'updated';
+
+    const registrationTestData = [
+      {
+        registrationFieldId: registrationFieldId,
+        value: updatedValue,
+      },
+    ];
+
+    const updatedData = await upsertRegistrationData({
+      dbPool,
+      registrationId: registrationId,
+      registrationData: registrationTestData,
+    });
+
+    // Assert that the function returns null when an error occurs
+    expect(updatedData).toBeNull();
+  });
+
   afterAll(async () => {
     await cleanup(dbPool);
     await dbConnection.end();

--- a/src/services/registrationData.ts
+++ b/src/services/registrationData.ts
@@ -3,7 +3,6 @@ import * as db from '../db';
 import { eq, and, isNotNull, inArray } from 'drizzle-orm';
 import type { Request, Response } from 'express';
 
-/* istanbul ignore next */
 export function getRegistrationData(dbPool: PostgresJsDatabase<typeof db>) {
   return async function (req: Request, res: Response) {
     const eventId = req.params.eventId;

--- a/src/services/registrationData.ts
+++ b/src/services/registrationData.ts
@@ -108,7 +108,7 @@ export async function upsertRegistrationData({
  * @param registrationFieldIds - Array of registration field IDs.
  * @returns An array of registration fields.
  */
-async function fetchRegistrationFields(
+export async function fetchRegistrationFields(
   dbPool: PostgresJsDatabase<typeof db>,
   registrationFieldIds: string[],
 ): Promise<

--- a/src/services/registrationData.ts
+++ b/src/services/registrationData.ts
@@ -3,6 +3,7 @@ import * as db from '../db';
 import { eq, and, isNotNull, inArray } from 'drizzle-orm';
 import type { Request, Response } from 'express';
 
+/* istanbul ignore next */
 export function getRegistrationData(dbPool: PostgresJsDatabase<typeof db>) {
   return async function (req: Request, res: Response) {
     const eventId = req.params.eventId;

--- a/src/services/registrationData.ts
+++ b/src/services/registrationData.ts
@@ -146,7 +146,7 @@ export async function fetchRegistrationFields(
  * @param registrationFields - An array of registration fields.
  * @returns Filtered registration data.
  */
-function filterRegistrationData(
+export function filterRegistrationData(
   registrationData: {
     id: string;
     registrationFieldId: string;

--- a/src/services/statistics.spec.ts
+++ b/src/services/statistics.spec.ts
@@ -7,7 +7,6 @@ import { insertVotesSchema } from '../types';
 import { cleanup, seed } from '../utils/db/seed';
 import { z } from 'zod';
 import { executeResultQueries } from './statistics';
-import { eq } from 'drizzle-orm';
 
 const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
 
@@ -16,7 +15,6 @@ describe('service: statistics', () => {
   let dbConnection: postgres.Sql<NonNullable<unknown>>;
   let userTestData: z.infer<typeof insertVotesSchema>;
   let otherUserTestData: z.infer<typeof insertVotesSchema>;
-  let cycle: db.Cycle | undefined;
   let questionOption: db.QuestionOption | undefined;
   let forumQuestion: db.ForumQuestion | undefined;
   let user: db.User | undefined;
@@ -34,7 +32,6 @@ describe('service: statistics', () => {
     forumQuestion = forumQuestions[0];
     user = users[0];
     otherUser = users[1];
-    cycle = cycles[0];
     userTestData = {
       numOfVotes: 2,
       optionId: questionOption?.id ?? '',

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -75,6 +75,12 @@ async function createRegistrationFields(dbPool: PostgresJsDatabase<typeof db>, e
         eventId,
         questionOptionType: 'SUBTITLE',
       },
+      {
+        name: 'other field',
+        type: 'TEXT',
+        required: false,
+        eventId,
+      },
     ])
     .returning();
 }

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -32,13 +32,13 @@ async function cleanup(dbPool: PostgresJsDatabase<typeof db>) {
   await dbPool.delete(db.userAttributes);
   await dbPool.delete(db.votes);
   await dbPool.delete(db.federatedCredentials);
+  await dbPool.delete(db.questionOptions);
   await dbPool.delete(db.registrationData);
   await dbPool.delete(db.registrationFields);
   await dbPool.delete(db.registrations);
   await dbPool.delete(db.usersToGroups);
   await dbPool.delete(db.users);
   await dbPool.delete(db.groups);
-  await dbPool.delete(db.questionOptions);
   await dbPool.delete(db.forumQuestions);
   await dbPool.delete(db.cycles);
   await dbPool.delete(db.events);
@@ -60,12 +60,22 @@ async function createRegistrationFields(dbPool: PostgresJsDatabase<typeof db>, e
 
   return dbPool
     .insert(db.registrationFields)
-    .values({
-      name: 'proposal title',
-      type: 'TEXT',
-      required: true,
-      eventId,
-    })
+    .values([
+      {
+        name: 'proposal title',
+        type: 'TEXT',
+        required: true,
+        eventId,
+        questionOptionType: 'TITLE',
+      },
+      {
+        name: 'proposal description',
+        type: 'TEXT',
+        required: true,
+        eventId,
+        questionOptionType: 'SUBTITLE',
+      },
+    ])
     .returning();
 }
 


### PR DESCRIPTION
PR increases test coverage of the `registrationData` service: 

![Screenshot 2024-03-06 155729](https://github.com/lexicongovernance/pluraltools-backend/assets/43137759/eeed78d3-006a-4add-9543-94d1ee90a085)
 