### PR TITLE
Update user service to check for existing email and username

### DIFF
--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -5,7 +5,17 @@ import { users } from '../db';
 export const groupIdsSchema = z.string().array();
 export const userAttributesSchema = z.record(z.string());
 
-export const insertUserSchema = createInsertSchema(users).extend({
-  groupIds: groupIdsSchema,
-  userAttributes: userAttributesSchema,
-});
+export const insertUserSchema = createInsertSchema(users)
+  .extend({
+    groupIds: groupIdsSchema,
+    userAttributes: userAttributesSchema,
+  })
+  .transform((data) => {
+    // make empty strings null
+    return {
+      ...data,
+      email: data.email || null,
+      username: data.username || null,
+      name: data.name || null,
+    };
+  });


### PR DESCRIPTION
## overview
this is a hotfix, right now creating a duplicate username or email can cause the server to crash.

with this solution it will return the error message and will avoid crashes