### PR TITLE
Configuration improvements 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,0 @@
-# exclude .js files from linting
-/dist/index.js
-drizzle.config.js
-jest.config.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     parser: '@typescript-eslint/parser',
     plugins: ['@typescript-eslint'],
     root: true,
+    ignorePatterns: ['dist', '.eslintrc.cjs', 'drizzle.config.js', 'jest.config.js'],
     rules: {
         '@typescript-eslint/ban-ts-comment': 'warn',
         '@typescript-eslint/no-var-requires': 'off',

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,4 +14,8 @@ module.exports = {
     'src/modules/**/*.ts',
     'src/services/**/*.ts',
   ],
+  coveragePathIgnorePatterns: [
+    '/src/services/auth/',
+  ],
+  silent: true, // surpress console output for passing tests 
 };

--- a/src/services/statistics.spec.ts
+++ b/src/services/statistics.spec.ts
@@ -7,7 +7,6 @@ import { insertVotesSchema } from '../types';
 import { cleanup, seed } from '../utils/db/seed';
 import { z } from 'zod';
 import { executeResultQueries } from './statistics';
-import { eq } from 'drizzle-orm';
 
 const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
 
@@ -16,7 +15,6 @@ describe('service: statistics', () => {
   let dbConnection: postgres.Sql<NonNullable<unknown>>;
   let userTestData: z.infer<typeof insertVotesSchema>;
   let otherUserTestData: z.infer<typeof insertVotesSchema>;
-  let cycle: db.Cycle | undefined;
   let questionOption: db.QuestionOption | undefined;
   let forumQuestion: db.ForumQuestion | undefined;
   let user: db.User | undefined;
@@ -28,13 +26,12 @@ describe('service: statistics', () => {
     dbPool = initDb.dbPool;
     dbConnection = initDb.connection;
     // seed
-    const { users, questionOptions, forumQuestions, cycles } = await seed(dbPool);
+    const { users, questionOptions, forumQuestions } = await seed(dbPool);
     // Insert registration fields for the user
     questionOption = questionOptions[0];
     forumQuestion = forumQuestions[0];
     user = users[0];
     otherUser = users[1];
-    cycle = cycles[0];
     userTestData = {
       numOfVotes: 2,
       optionId: questionOption?.id ?? '',


### PR DESCRIPTION
This PR improves our configuration: 

1. Delete `.eslintignore` file and include the ignore patterns in the `eslintrc.js` file to make it consistent with how we do it in the frontend

2. Exclude the `services/auth` directory from test converage reports as I dont think that is something that needs tests. 

3. Surpress console logs for passing tests. This has become an issue, especially since the quantity of tests is increasing. When you run `pnpm test` then the oputput is as follows: 

![current-situation](https://github.com/lexicongovernance/pluraltools-backend/assets/43137759/da8ecdff-2a39-41a4-b9ae-209af50b7127)

However, by surpressing logs for passing tests the output will look as follows (maybe it also increases the speed a bit):

![resutl](https://github.com/lexicongovernance/pluraltools-backend/assets/43137759/78dd0c47-9b4a-4e75-bcef-a8a5e896e253)

However, when a test fails the logs will be displayed. Even better only logs for faild tests will be displayed which makes it easier to locate them: 

![only show failing tests](https://github.com/lexicongovernance/pluraltools-backend/assets/43137759/d7d17c02-7b2d-4430-9293-12e26ca173cf)

