### PR TITLE
Add dummy multiplier service

### DIFF
--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -183,10 +183,6 @@ export function updateUser(dbPool: PostgresJsDatabase<typeof db>) {
         body.data.userAttributes,
       );
 
-      console.log('updatedGroups', updatedGroups);
-      console.log('updatedMultiplier', updatedMultiplier);
-      console.log('updatedUserAttributes', updatedUserAttributes);
-
       return res.json({ data: { user, updatedGroups, updatedMultiplier, updatedUserAttributes } });
     } catch (e) {
       console.error(`[ERROR] ${JSON.stringify(e)}`);

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -5,6 +5,7 @@ import { and, eq, ne, or } from 'drizzle-orm';
 import { UserData, insertUserSchema } from '../types/users';
 import { upsertUsersToGroups } from './usersToGroups';
 import { upsertUserAttributes } from './userAttributes';
+import { upsertUsersToMultipliers } from './usersToMultipliers';
 
 /**
  * Retrieves user data from the database.
@@ -174,13 +175,19 @@ export function updateUser(dbPool: PostgresJsDatabase<typeof db>) {
 
       const updatedGroups = await upsertUsersToGroups(dbPool, userId, body.data.groupIds);
 
+      const updatedMultiplier = await upsertUsersToMultipliers(dbPool, userId);
+
       const updatedUserAttributes = await upsertUserAttributes(
         dbPool,
         userId,
         body.data.userAttributes,
       );
 
-      return res.json({ data: { user, updatedGroups, updatedUserAttributes } });
+      console.log('updatedGroups', updatedGroups);
+      console.log('updatedMultiplier', updatedMultiplier);
+      console.log('updatedUserAttributes', updatedUserAttributes);
+
+      return res.json({ data: { user, updatedGroups, updatedMultiplier, updatedUserAttributes } });
     } catch (e) {
       console.error(`[ERROR] ${JSON.stringify(e)}`);
       return res.sendStatus(500);

--- a/src/services/usersToMultipliers.ts
+++ b/src/services/usersToMultipliers.ts
@@ -1,0 +1,35 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as db from '../db';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Upserts user-multiplier relationships in the database.
+ *
+ * @param {PostgresJsDatabase<typeof db>} dbPool - The database connection pool.
+ * @param {string} userId - The ID of the user for whom the multiplier is being set.
+ * @returns {Promise<db.UsersToMultipliers[] | null>} A promise resolving to an array of user-multiplier objects if successful, otherwise null.
+ */
+export async function upsertUsersToMultipliers(
+  dbPool: PostgresJsDatabase<typeof db>,
+  userId: string,
+): Promise<db.UsersToMultipliers[] | null> {
+  // delete the existing user to multiplier relationship
+  try {
+    await dbPool.delete(db.usersToMultipliers).where(eq(db.usersToMultipliers.userId, userId));
+
+    const multipliers = await dbPool.query.multipliers.findFirst({
+      where: eq(db.multipliers.multiplier, '1.0'),
+    });
+
+    // save the new multiplier Id
+    const newUserToMultiplier = await dbPool
+      .insert(db.usersToMultipliers)
+      .values({ userId, multiplierId: multipliers!.id })
+      .returning();
+
+    return newUserToMultiplier;
+  } catch (e) {
+    console.log('error upserting users to multipliers' + JSON.stringify(e));
+    return null;
+  }
+}


### PR DESCRIPTION
This PR adds a dummy users to multiplier service that assigns a multiplier of 1 to each new user that submits an account registrations. Therefore, this allows us to test our application and start developing the multipler feature also from a frontend perspective. Furthermore, it can serve as a framework that can be extended to incorporate the actual users to multipliers service.