### PR TITLE
Add user schema test and update insertUserSchema

### DIFF
--- a/src/services/users.spec.ts
+++ b/src/services/users.spec.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { insertUserSchema } from '../types/users';
+
+describe('service: users', function () {
+  describe('schema: insertUserSchema', function () {
+    it('should remove empty strings from user data', function () {
+      const user: z.infer<typeof insertUserSchema> = {
+        email: '',
+        username: '',
+        firstName: '',
+        lastName: '',
+        telegram: '',
+        groupIds: ['1'],
+        userAttributes: {},
+      };
+
+      const transformedUser: { [key: string]: string | null | string[] | object } =
+        insertUserSchema.parse(user);
+
+      // loop through all keys and check if they are not empty strings
+
+      for (const key of Object.keys(transformedUser)) {
+        console.log(key);
+        expect(transformedUser[key]).not.toBe('');
+      }
+    });
+  });
+});

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -17,6 +17,7 @@ export const insertUserSchema = createInsertSchema(users)
       email: data.email || null,
       username: data.username || null,
       firstName: data.firstName || null,
+      telegram: data.telegram || null,
       lastName: data.lastName || null,
     };
   });


### PR DESCRIPTION
## overview
removes any chance of empty strings on user update body, making sure if we add another field an error on repeating "" will not happen. "" -> NULL is what we would want to handle.

also patches telegram issue by converting it to null