### PR TITLE
Add api for group categories

### DIFF
--- a/src/handlers/groupCategories.ts
+++ b/src/handlers/groupCategories.ts
@@ -1,0 +1,27 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { Request, Response } from 'express';
+import * as db from '../db';
+import { eq } from 'drizzle-orm';
+
+export function getGroupCategoriesHandler(dbPool: PostgresJsDatabase<typeof db>) {
+  return async function (req: Request, res: Response) {
+    const groupCategories = await dbPool.query.groupCategories.findMany();
+    return res.json({ data: groupCategories });
+  };
+}
+
+export function getGroupCategoryHandler(dbPool: PostgresJsDatabase<typeof db>) {
+  return async function (req: Request, res: Response) {
+    const groupCategoryId = req.params.id;
+
+    if (!groupCategoryId) {
+      return res.status(400).json({ error: 'Group Category ID is required' });
+    }
+
+    const groupCategory = await dbPool.query.groupCategories.findFirst({
+      where: eq(db.groupCategories.id, groupCategoryId),
+    });
+
+    return res.json({ data: groupCategory });
+  };
+}

--- a/src/handlers/users.ts
+++ b/src/handlers/users.ts
@@ -95,7 +95,11 @@ export function getUserGroupsHandler(dbPool: PostgresJsDatabase<typeof db>) {
     try {
       const query = await dbPool.query.usersToGroups.findMany({
         with: {
-          group: true,
+          group: {
+            with: {
+              groupCategory: true,
+            },
+          },
         },
         where: eq(db.usersToGroups.userId, userId),
       });

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -54,6 +54,7 @@ export function apiRouter({
   router.use('/groups', groupsRouter({ dbPool }));
   router.use('/comments', commentsRouter({ dbPool }));
   router.use('/options', optionsRouter({ dbPool }));
+  router.use('/group-categories', optionsRouter({ dbPool }));
 
   return router;
 }

--- a/src/routers/groupCategories.ts
+++ b/src/routers/groupCategories.ts
@@ -1,0 +1,14 @@
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { default as express } from 'express';
+import type * as db from '../db';
+import { isLoggedIn } from '../middleware/isLoggedIn';
+import { getGroupCategoriesHandler, getGroupCategoryHandler } from '../handlers/groupCategories';
+
+const router = express.Router();
+
+export function groupCategoriesRouter({ dbPool }: { dbPool: PostgresJsDatabase<typeof db> }) {
+  router.get('/', isLoggedIn(dbPool), getGroupCategoriesHandler(dbPool));
+  router.get('/:id', isLoggedIn(dbPool), getGroupCategoryHandler(dbPool));
+
+  return router;
+}


### PR DESCRIPTION
closes https://github.com/lexicongovernance/pluraltools-backend/issues/306

## overview
adds a new router to communicate with group-categories and also when a user sees what group he is a part of, it will include the category so the frontend can use this endpoint to check what category a user can register to