### PR TITLE
Update vote service to allow for different grouping dimensions when calculating the plurality score 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,5 @@ module.exports = {
   collectCoverage: false,
   collectCoverageFrom: ['src/modules/**/*.ts', 'src/services/**/*.ts'],
   coveragePathIgnorePatterns: ['/src/handlers/'],
-  silent: true, // surpress console output for passing tests
+  //silent: true, // surpress console output for passing tests
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,5 @@ module.exports = {
   collectCoverage: false,
   collectCoverageFrom: ['src/modules/**/*.ts', 'src/services/**/*.ts'],
   coveragePathIgnorePatterns: ['/src/handlers/'],
-  //silent: true, // surpress console output for passing tests
+  silent: true, // surpress console output for passing tests
 };

--- a/src/services/statistics.spec.ts
+++ b/src/services/statistics.spec.ts
@@ -84,7 +84,7 @@ describe('service: statistics', () => {
         expect(optionStat?.distinctUsers).toEqual(2);
         expect(optionStat?.allocatedHearts).toEqual(8);
         expect(optionStat?.quadraticScore).toEqual('4');
-        expect(optionStat?.distinctGroups).toEqual(1);
+        expect(optionStat?.distinctGroups).toEqual(2);
         const listOfGroupNames = optionStat?.listOfGroupNames;
         // Check if the array is not empty
         expect(listOfGroupNames).toBeDefined();

--- a/src/services/votes.spec.ts
+++ b/src/services/votes.spec.ts
@@ -239,13 +239,10 @@ describe('service: votes', () => {
     // Get vote data required for groups
     const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
     const votesDictionary = await numOfVotesDictionary(voteArray);
-    console.log('voteArray', voteArray);
-    console.log('votesDictionary', votesDictionary);
 
     const groups = await groupsDictionary(dbPool, votesDictionary, [
       '00000000-0000-0000-0000-000000000000',
     ]);
-    console.log('groups', groups);
 
     expect(groups).toBeDefined();
     expect(groups['unexpectedKey']).toBeUndefined();

--- a/src/services/votes.spec.ts
+++ b/src/services/votes.spec.ts
@@ -18,7 +18,7 @@ import {
   updateVoteScore,
   userCanVote,
 } from './votes';
-import { eq, isNull } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 
 const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
 

--- a/src/services/votes.spec.ts
+++ b/src/services/votes.spec.ts
@@ -204,8 +204,9 @@ describe('service: votes', () => {
     // Get vote data required for groups
     const groupCategoriesIdArray = await queryGroupCategories(dbPool, otherForumQuestion!.id);
     expect(groupCategoriesIdArray).toBeDefined();
-    expect(groupCategoriesIdArray.length).toBe(0);
+    expect(groupCategoriesIdArray.length).toBe(1);
     expect(Array.isArray(groupCategoriesIdArray)).toBe(true);
+    expect(groupCategoriesIdArray).toEqual(['00000000-0000-0000-0000-000000000000']);
   });
 
   test('only return groups for users who voted for the option', async () => {
@@ -234,7 +235,6 @@ describe('service: votes', () => {
     expect(groups[Object.keys(groups)[0]!]!.length).toEqual(2);
   });
 
-  /*
   test('only return baseline groups when no addtional group category gets provided', async () => {
     // Get vote data required for groups
     const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
@@ -242,7 +242,9 @@ describe('service: votes', () => {
     console.log('voteArray', voteArray);
     console.log('votesDictionary', votesDictionary);
 
-    const groups = await groupsDictionary(dbPool, votesDictionary, []);
+    const groups = await groupsDictionary(dbPool, votesDictionary, [
+      '00000000-0000-0000-0000-000000000000',
+    ]);
     console.log('groups', groups);
 
     expect(groups).toBeDefined();
@@ -251,7 +253,6 @@ describe('service: votes', () => {
     expect(Object.keys(groups).length).toEqual(1);
     expect(groups[Object.keys(groups)[0]!]!.length).toEqual(2);
   });
-  */
 
   test('should calculate the plural score correctly', () => {
     // Mock groups dictionary

--- a/src/services/votes.spec.ts
+++ b/src/services/votes.spec.ts
@@ -197,7 +197,7 @@ describe('service: votes', () => {
     expect(groups).toBeDefined();
     expect(groups['unexpectedKey']).toBeUndefined();
     expect(typeof groups).toBe('object');
-    expect(Object.keys(groups).length).toEqual(1);
+    expect(Object.keys(groups).length).toEqual(2);
     expect(groups[Object.keys(groups)[0]!]!.length).toEqual(2);
   });
 

--- a/src/services/votes.spec.ts
+++ b/src/services/votes.spec.ts
@@ -17,7 +17,7 @@ import {
   updateVoteScore,
   userCanVote,
 } from './votes';
-import { eq } from 'drizzle-orm';
+import { eq, isNull } from 'drizzle-orm';
 
 const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
 
@@ -29,6 +29,7 @@ describe('service: votes', () => {
   let questionOption: db.QuestionOption | undefined;
   let otherQuestionOption: db.QuestionOption | undefined;
   let forumQuestion: db.ForumQuestion | undefined;
+  let groupCategory: db.GroupCategory | undefined;
   let user: db.User | undefined;
   let secondUser: db.User | undefined;
   let thirdUser: db.User | undefined;
@@ -38,11 +39,12 @@ describe('service: votes', () => {
     dbPool = initDb.dbPool;
     dbConnection = initDb.connection;
     // seed
-    const { users, questionOptions, forumQuestions, cycles } = await seed(dbPool);
+    const { users, questionOptions, forumQuestions, cycles, groupCategories } = await seed(dbPool);
     // Insert registration fields for the user
     questionOption = questionOptions[0];
     otherQuestionOption = questionOptions[1];
     forumQuestion = forumQuestions[0];
+    groupCategory = groupCategories[0];
     user = users[0];
     secondUser = users[1];
     thirdUser = users[2];
@@ -186,7 +188,11 @@ describe('service: votes', () => {
     // Get vote data required for groups
     const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
     const votesDictionary = await numOfVotesDictionary(voteArray);
-    const groups = await groupsDictionary(dbPool, votesDictionary);
+    console.log('voteArray', voteArray);
+    console.log('votesDictionary', votesDictionary);
+
+    const groups = await groupsDictionary(dbPool, votesDictionary, [groupCategory!.id]);
+    console.log('groups', groups);
 
     expect(groups).toBeDefined();
     expect(groups['unexpectedKey']).toBeUndefined();

--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -78,13 +78,40 @@ export function numOfVotesDictionary(voteArray: Array<{ userId: string; numOfVot
   return numOfVotesDictionary;
 }
 
+export async function queryGroupCategories(
+  dbPool: PostgresJsDatabase<typeof db>,
+  questionId: string,
+): Promise<(string | null)[] | null> {
+  const groupCategories = await dbPool
+    .select({
+      groupCategoryId: db.questionsToGroupCategories.groupCategoryId,
+    })
+    .from(db.questionsToGroupCategories)
+    .where(eq(db.questionsToGroupCategories.questionId, questionId));
+
+  // Need to due this adjustment because currently group_category_id is nullable due to affiliations having no label.
+  const groupCategoryIds = groupCategories
+    .map((category) => category.groupCategoryId)
+    .filter((id) => id !== null) as string[];
+
+  // Returning null if there are no group categories found
+  if (groupCategoryIds.length === 0) {
+    return null;
+  }
+
+  return groupCategoryIds;
+}
+
 /**
  * Queries group data and creates group dictionary based on user IDs and option ID.
- * @param {PostgresJsDatabase<typeof db>} dbPool - The database connection pool.
+ * @param {Record<string, number>} numOfVotesDictionary - Dictionary of user IDs and their respective number of votes.
+ * @param {Array<string | null>} groupCategoryIds - Array of group category IDs.
+ * @returns {Promise<Record<string, string[]>>} - Dictionary of group IDs and their corresponding user IDs.
  */
 export async function groupsDictionary(
   dbPool: PostgresJsDatabase<typeof db>,
   numOfVotesDictionary: Record<string, number>,
+  groupCategories: Array<string | null>,
 ) {
   const groupArray = await dbPool.execute<{ groupId: string; userIds: string[] }>(
     sql.raw(`
@@ -93,6 +120,9 @@ export async function groupsDictionary(
       WHERE user_id IN (${Object.keys(numOfVotesDictionary)
         .map((id) => `'${id}'`)
         .join(', ')})
+      AND (group_category_id IN (${groupCategories
+        .map((category) => `'${category}'`)
+        .join(', ')}) OR group_category_id IS NULL)
       GROUP BY group_id
     `),
   );
@@ -171,8 +201,19 @@ export async function updateVoteScore(
   // Transform data
   const votesDictionary = await numOfVotesDictionary(voteArray);
 
+  // Query question Id
+  const queryQuestionId = await dbPool
+    .select({
+      questionId: db.questionOptions.questionId,
+    })
+    .from(db.questionOptions)
+    .where(eq(db.questionOptions.id, optionId));
+
+  // Query group categories
+  const groupCategories = await queryGroupCategories(dbPool, queryQuestionId[0]!.questionId);
+
   // Query group data
-  const groupArray = await groupsDictionary(dbPool, votesDictionary);
+  const groupArray = await groupsDictionary(dbPool, votesDictionary, groupCategories ?? []);
 
   // Perform plural voting calculation
   const score = await calculatePluralScore(groupArray, votesDictionary);

--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -127,7 +127,7 @@ export async function groupsDictionary(
     `),
   );
 
-  console.log('groupArrayCode', groupArray);
+  //console.log('groupArrayCode', groupArray); OR group_category_id IS NULL
 
   const groupsDictionary = groupArray.reduce(
     (acc, group) => {
@@ -136,7 +136,7 @@ export async function groupsDictionary(
     },
     {} as Record<string, string[]>,
   );
-  console.log('groupsDictionary', groupsDictionary);
+  //console.log('groupsDictionary', groupsDictionary);
 
   return groupsDictionary;
 }

--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -81,7 +81,7 @@ export function numOfVotesDictionary(voteArray: Array<{ userId: string; numOfVot
 export async function queryGroupCategories(
   dbPool: PostgresJsDatabase<typeof db>,
   questionId: string,
-): Promise<(string | null)[] | null> {
+): Promise<string[]> {
   const groupCategories = await dbPool
     .select({
       groupCategoryId: db.questionsToGroupCategories.groupCategoryId,
@@ -96,7 +96,7 @@ export async function queryGroupCategories(
 
   // Returning null if there are no group categories found
   if (groupCategoryIds.length === 0) {
-    return null;
+    return [];
   }
 
   return groupCategoryIds;
@@ -105,13 +105,13 @@ export async function queryGroupCategories(
 /**
  * Queries group data and creates group dictionary based on user IDs and option ID.
  * @param {Record<string, number>} numOfVotesDictionary - Dictionary of user IDs and their respective number of votes.
- * @param {Array<string | null>} groupCategoryIds - Array of group category IDs.
+ * @param {Array<string>} groupCategoryIds - Array of group category IDs.
  * @returns {Promise<Record<string, string[]>>} - Dictionary of group IDs and their corresponding user IDs.
  */
 export async function groupsDictionary(
   dbPool: PostgresJsDatabase<typeof db>,
   numOfVotesDictionary: Record<string, number>,
-  groupCategories: Array<string | null>,
+  groupCategories: Array<string>,
 ) {
   const groupArray = await dbPool.execute<{ groupId: string; userIds: string[] }>(
     sql.raw(`
@@ -127,6 +127,8 @@ export async function groupsDictionary(
     `),
   );
 
+  console.log('groupArrayCode', groupArray);
+
   const groupsDictionary = groupArray.reduce(
     (acc, group) => {
       acc[group.groupId] = group.userIds ?? [];
@@ -134,6 +136,7 @@ export async function groupsDictionary(
     },
     {} as Record<string, string[]>,
   );
+  console.log('groupsDictionary', groupsDictionary);
 
   return groupsDictionary;
 }

--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -127,8 +127,6 @@ export async function groupsDictionary(
     `),
   );
 
-  //console.log('groupArrayCode', groupArray); OR group_category_id IS NULL
-
   const groupsDictionary = groupArray.reduce(
     (acc, group) => {
       acc[group.groupId] = group.userIds ?? [];
@@ -136,7 +134,6 @@ export async function groupsDictionary(
     },
     {} as Record<string, string[]>,
   );
-  //console.log('groupsDictionary', groupsDictionary);
 
   return groupsDictionary;
 }

--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -94,9 +94,9 @@ export async function queryGroupCategories(
     .map((category) => category.groupCategoryId)
     .filter((id) => id !== null) as string[];
 
-  // Returning null if there are no group categories found
+  // Returning dummy uuid if there are no group categories found
   if (groupCategoryIds.length === 0) {
-    return [];
+    return ['00000000-0000-0000-0000-000000000000'];
   }
 
   return groupCategoryIds;

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -214,6 +214,16 @@ async function createUsersToGroups(
     groupId: index < 2 ? groupIds[0]! : groupIds[1]!,
     groupCategoryId,
   }));
+
+  // Add baseline group for each user (i.e. each user must be assigned to at least one group at all times)
+  userIds.forEach((userId) => {
+    usersToGroups.push({
+      userId,
+      groupId: groupIds[3]!,
+      groupCategoryId: undefined, // udefined because currently affiliation does not have a group category id
+    });
+  });
+
   return dbPool.insert(db.usersToGroups).values(usersToGroups).returning();
 }
 

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -17,6 +17,12 @@ async function seed(dbPool: PostgresJsDatabase<typeof db>) {
     groups.map((g) => g.id!),
     groupCategories[0]?.id,
   );
+  const questionsToGroupCategories = await createQuestionsToGroupCategories(
+    dbPool,
+    forumQuestions[0]!.id,
+    groupCategories[0]?.id,
+    groupCategories[1]?.id,
+  );
 
   return {
     events,
@@ -28,6 +34,7 @@ async function seed(dbPool: PostgresJsDatabase<typeof db>) {
     users,
     usersToGroups,
     registrationFields,
+    questionsToGroupCategories,
   };
 }
 
@@ -43,6 +50,7 @@ async function cleanup(dbPool: PostgresJsDatabase<typeof db>) {
   await dbPool.delete(db.users);
   await dbPool.delete(db.groups);
   await dbPool.delete(db.groupCategories);
+  await dbPool.delete(db.questionsToGroupCategories);
   await dbPool.delete(db.forumQuestions);
   await dbPool.delete(db.cycles);
   await dbPool.delete(db.events);
@@ -207,6 +215,27 @@ async function createUsersToGroups(
     groupCategoryId,
   }));
   return dbPool.insert(db.usersToGroups).values(usersToGroups).returning();
+}
+
+async function createQuestionsToGroupCategories(
+  dbPool: PostgresJsDatabase<typeof db>,
+  questionId: string,
+  groupCategoryIdOne?: string,
+  groupCategoryIdTwo?: string,
+) {
+  return dbPool
+    .insert(db.questionsToGroupCategories)
+    .values([
+      {
+        questionId: questionId,
+        groupCategoryId: groupCategoryIdOne,
+      },
+      {
+        questionId: questionId,
+        groupCategoryId: groupCategoryIdTwo,
+      },
+    ])
+    .returning();
 }
 
 export { seed, cleanup };

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -122,10 +122,16 @@ async function createForumQuestions(dbPool: PostgresJsDatabase<typeof db>, cycle
 
   return dbPool
     .insert(db.forumQuestions)
-    .values({
-      cycleId,
-      questionTitle: "What's your favorite movie?",
-    })
+    .values([
+      {
+        cycleId,
+        questionTitle: "What's your favorite movie?",
+      },
+      {
+        cycleId,
+        questionTitle: 'What is your favorit fruit?',
+      },
+    ])
     .returning();
 }
 

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -49,8 +49,8 @@ async function cleanup(dbPool: PostgresJsDatabase<typeof db>) {
   await dbPool.delete(db.usersToGroups);
   await dbPool.delete(db.users);
   await dbPool.delete(db.groups);
-  await dbPool.delete(db.groupCategories);
   await dbPool.delete(db.questionsToGroupCategories);
+  await dbPool.delete(db.groupCategories);
   await dbPool.delete(db.forumQuestions);
   await dbPool.delete(db.cycles);
   await dbPool.delete(db.events);


### PR DESCRIPTION
This PR allows to specify group categories that should be taken into account for the plurality score calculation by `question_id`. 

However, there is one complicating factor. Our main grouping dimension `affiliation` is not related to a group category. Therefore, we must allow for it to be a group category of type `null` in the `usersToGroups` table. Nevertheless this is not a group category in the group categories table becaus it cannot have an id that is not null. 

requiring a group category id would simplify the code dramatically. We should think it implement the following migration prior to the event: https://github.com/lexicongovernance/pluraltools-backend/issues/300