### PR TITLE
Add secret code service

### DIFF
--- a/migrations/0016_ambitious_rictor.sql
+++ b/migrations/0016_ambitious_rictor.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "group_categories" ADD COLUMN "user_can_create" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "group_categories" ADD COLUMN "user_can_view" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "groups" ADD COLUMN "secret" varchar(256);--> statement-breakpoint
+ALTER TABLE "groups" ADD CONSTRAINT "groups_secret_unique" UNIQUE("secret");

--- a/migrations/0016_motionless_quasar.sql
+++ b/migrations/0016_motionless_quasar.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "group_categories" ADD COLUMN "private" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "groups" ADD COLUMN "secret" varchar(256);

--- a/migrations/0016_motionless_quasar.sql
+++ b/migrations/0016_motionless_quasar.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "group_categories" ADD COLUMN "private" boolean DEFAULT false NOT NULL;--> statement-breakpoint
-ALTER TABLE "groups" ADD COLUMN "secret" varchar(256);

--- a/migrations/meta/0016_snapshot.json
+++ b/migrations/meta/0016_snapshot.json
@@ -1,0 +1,1540 @@
+{
+  "id": "d4a280a6-c61f-4699-9b39-76f63cbcc882",
+  "prevId": "52b7a687-9af1-4d59-8443-195f60d1d1f5",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_option_id": {
+          "name": "question_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_question_option_id_question_options_id_fk": {
+          "name": "comments_question_option_id_question_options_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "cycles": {
+      "name": "cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UPCOMING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cycles_event_id_events_id_fk": {
+          "name": "cycles_event_id_events_id_fk",
+          "tableFrom": "cycles",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_description": {
+          "name": "registration_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_display_rank": {
+          "name": "event_display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "federated_credentials": {
+      "name": "federated_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federated_credentials_user_id_users_id_fk": {
+          "name": "federated_credentials_user_id_users_id_fk",
+          "tableFrom": "federated_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_subject_idx": {
+          "name": "provider_subject_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "subject"
+          ]
+        }
+      }
+    },
+    "forum_questions": {
+      "name": "forum_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cycle_id": {
+          "name": "cycle_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_title": {
+          "name": "question_title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_sub_title": {
+          "name": "question_sub_title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forum_questions_cycle_id_cycles_id_fk": {
+          "name": "forum_questions_cycle_id_cycles_id_fk",
+          "tableFrom": "forum_questions",
+          "tableTo": "cycles",
+          "columnsFrom": [
+            "cycle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "group_categories": {
+      "name": "group_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_categories_event_id_events_id_fk": {
+          "name": "group_categories_event_id_events_id_fk",
+          "tableFrom": "group_categories",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_category_id": {
+          "name": "group_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groups_group_category_id_group_categories_id_fk": {
+          "name": "groups_group_category_id_group_categories_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "group_categories",
+          "columnsFrom": [
+            "group_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_telegram_unique": {
+          "name": "users_telegram_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "telegram"
+          ]
+        }
+      }
+    },
+    "registrations": {
+      "name": "registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'DRAFT'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registrations_user_id_users_id_fk": {
+          "name": "registrations_user_id_users_id_fk",
+          "tableFrom": "registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "registrations_event_id_events_id_fk": {
+          "name": "registrations_event_id_events_id_fk",
+          "tableFrom": "registrations",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "registrations_group_id_groups_id_fk": {
+          "name": "registrations_group_id_groups_id_fk",
+          "tableFrom": "registrations",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "registration_field_options": {
+      "name": "registration_field_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "registration_field_id": {
+          "name": "registration_field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_field_options_registration_field_id_registration_fields_id_fk": {
+          "name": "registration_field_options_registration_field_id_registration_fields_id_fk",
+          "tableFrom": "registration_field_options",
+          "tableTo": "registration_fields",
+          "columnsFrom": [
+            "registration_field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_title": {
+          "name": "option_title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_sub_title": {
+          "name": "option_sub_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "vote_score": {
+          "name": "vote_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_user_id_users_id_fk": {
+          "name": "question_options_user_id_users_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_options_registration_id_registrations_id_fk": {
+          "name": "question_options_registration_id_registrations_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_options_question_id_forum_questions_id_fk": {
+          "name": "question_options_question_id_forum_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "forum_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_of_votes": {
+          "name": "num_of_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_option_id_question_options_id_fk": {
+          "name": "votes_option_id_question_options_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_question_id_forum_questions_id_fk": {
+          "name": "votes_question_id_forum_questions_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "forum_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "registration_fields": {
+      "name": "registration_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'TEXT'"
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_option_type": {
+          "name": "question_option_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields_display_rank": {
+          "name": "fields_display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_limit": {
+          "name": "character_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_fields_event_id_events_id_fk": {
+          "name": "registration_fields_event_id_events_id_fk",
+          "tableFrom": "registration_fields",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "registration_fields_question_id_forum_questions_id_fk": {
+          "name": "registration_fields_question_id_forum_questions_id_fk",
+          "tableFrom": "registration_fields",
+          "tableTo": "forum_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "registration_data": {
+      "name": "registration_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_field_id": {
+          "name": "registration_field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_data_registration_id_registrations_id_fk": {
+          "name": "registration_data_registration_id_registrations_id_fk",
+          "tableFrom": "registration_data",
+          "tableTo": "registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "registration_data_registration_field_id_registration_fields_id_fk": {
+          "name": "registration_data_registration_field_id_registration_fields_id_fk",
+          "tableFrom": "registration_data",
+          "tableTo": "registration_fields",
+          "columnsFrom": [
+            "registration_field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users_to_groups": {
+      "name": "users_to_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_category_id": {
+          "name": "group_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_groups_user_id_users_id_fk": {
+          "name": "users_to_groups_user_id_users_id_fk",
+          "tableFrom": "users_to_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_groups_group_id_groups_id_fk": {
+          "name": "users_to_groups_group_id_groups_id_fk",
+          "tableFrom": "users_to_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_groups_group_category_id_group_categories_id_fk": {
+          "name": "users_to_groups_group_category_id_group_categories_id_fk",
+          "tableFrom": "users_to_groups",
+          "tableTo": "group_categories",
+          "columnsFrom": [
+            "group_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "user_attributes": {
+      "name": "user_attributes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribute_key": {
+          "name": "attribute_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribute_value": {
+          "name": "attribute_value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_attributes_user_id_users_id_fk": {
+          "name": "user_attributes_user_id_users_id_fk",
+          "tableFrom": "user_attributes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "likes_user_id_users_id_fk": {
+          "name": "likes_user_id_users_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "likes_comment_id_comments_id_fk": {
+          "name": "likes_comment_id_comments_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "notification_types": {
+      "name": "notification_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_types_value_unique": {
+          "name": "notification_types_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "value"
+          ]
+        }
+      }
+    },
+    "users_to_notifications": {
+      "name": "users_to_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_type_id": {
+          "name": "notification_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_notifications_user_id_users_id_fk": {
+          "name": "users_to_notifications_user_id_users_id_fk",
+          "tableFrom": "users_to_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_notifications_notification_type_id_notification_types_id_fk": {
+          "name": "users_to_notifications_notification_type_id_notification_types_id_fk",
+          "tableFrom": "users_to_notifications",
+          "tableTo": "notification_types",
+          "columnsFrom": [
+            "notification_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "questions_to_group_categories": {
+      "name": "questions_to_group_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_category_id": {
+          "name": "group_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_to_group_categories_question_id_forum_questions_id_fk": {
+          "name": "questions_to_group_categories_question_id_forum_questions_id_fk",
+          "tableFrom": "questions_to_group_categories",
+          "tableTo": "forum_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "questions_to_group_categories_group_category_id_group_categories_id_fk": {
+          "name": "questions_to_group_categories_group_category_id_group_categories_id_fk",
+          "tableFrom": "questions_to_group_categories",
+          "tableTo": "group_categories",
+          "columnsFrom": [
+            "group_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0016_snapshot.json
+++ b/migrations/meta/0016_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "d4a280a6-c61f-4699-9b39-76f63cbcc882",
+  "id": "3bca2de9-9a2c-46ce-87c8-226969d43ec7",
   "prevId": "52b7a687-9af1-4d59-8443-195f60d1d1f5",
   "version": "5",
   "dialect": "pg",
@@ -375,8 +375,15 @@
           "primaryKey": false,
           "notNull": false
         },
-        "private": {
-          "name": "private",
+        "user_can_create": {
+          "name": "user_can_create",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_can_view": {
+          "name": "user_can_view",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
@@ -483,7 +490,15 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {}
+      "uniqueConstraints": {
+        "groups_secret_unique": {
+          "name": "groups_secret_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret"
+          ]
+        }
+      }
     },
     "users": {
       "name": "users",

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1712769381020,
       "tag": "0015_shiny_black_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "5",
+      "when": 1712840195105,
+      "tag": "0016_motionless_quasar",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -117,8 +117,8 @@
     {
       "idx": 16,
       "version": "5",
-      "when": 1712840195105,
-      "tag": "0016_motionless_quasar",
+      "when": 1712848852970,
+      "tag": "0016_ambitious_rictor",
       "breakpoints": true
     }
   ]

--- a/src/db/groupCategories.ts
+++ b/src/db/groupCategories.ts
@@ -9,7 +9,8 @@ export const groupCategories = pgTable('group_categories', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: varchar('name'),
   eventId: uuid('event_id').references(() => events.id),
-  private: boolean('private').notNull().default(false),
+  userCanCreate: boolean('user_can_create').notNull().default(false),
+  userCanView: boolean('user_can_view').notNull().default(false),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });

--- a/src/db/groupCategories.ts
+++ b/src/db/groupCategories.ts
@@ -1,4 +1,4 @@
-import { pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
+import { pgTable, timestamp, uuid, varchar, boolean } from 'drizzle-orm/pg-core';
 import { events } from './events';
 import { groups } from './groups';
 import { usersToGroups } from './usersToGroups';
@@ -9,6 +9,7 @@ export const groupCategories = pgTable('group_categories', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: varchar('name'),
   eventId: uuid('event_id').references(() => events.id),
+  private: boolean('private').notNull().default(false),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });

--- a/src/db/groups.ts
+++ b/src/db/groups.ts
@@ -8,6 +8,7 @@ export const groups = pgTable('groups', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: varchar('name', { length: 256 }).notNull(),
   description: varchar('description', { length: 256 }),
+  secret: varchar('secret', { length: 256 }),
   groupCategoryId: uuid('group_category_id').references(() => groupCategories.id),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),

--- a/src/db/groups.ts
+++ b/src/db/groups.ts
@@ -8,7 +8,7 @@ export const groups = pgTable('groups', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: varchar('name', { length: 256 }).notNull(),
   description: varchar('description', { length: 256 }),
-  secret: varchar('secret', { length: 256 }),
+  secret: varchar('secret', { length: 256 }).unique(),
   groupCategoryId: uuid('group_category_id').references(() => groupCategories.id),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),

--- a/src/handlers/groupCategories.ts
+++ b/src/handlers/groupCategories.ts
@@ -2,6 +2,7 @@ import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { Request, Response } from 'express';
 import * as db from '../db';
 import { eq } from 'drizzle-orm';
+import { canViewGroupCategory } from '../services/groupCategories';
 
 export function getGroupCategoriesHandler(dbPool: PostgresJsDatabase<typeof db>) {
   return async function (req: Request, res: Response) {
@@ -23,5 +24,29 @@ export function getGroupCategoryHandler(dbPool: PostgresJsDatabase<typeof db>) {
     });
 
     return res.json({ data: groupCategory });
+  };
+}
+
+export function getGroupCategoriesGroupsHandler(dbPool: PostgresJsDatabase<typeof db>) {
+  return async function (req: Request, res: Response) {
+    const groupCategoryId = req.params.id;
+
+    if (!groupCategoryId) {
+      return res.status(400).json({ error: 'Group Category ID is required' });
+    }
+
+    const canView = await canViewGroupCategory(dbPool, groupCategoryId);
+
+    if (!canView) {
+      return res
+        .status(403)
+        .json({ error: 'You do not have permission to view this group category' });
+    }
+
+    const groups = await dbPool.query.groups.findMany({
+      where: eq(db.groups.groupCategoryId, groupCategoryId),
+    });
+
+    return res.json({ data: groups });
   };
 }

--- a/src/handlers/groupCategories.ts
+++ b/src/handlers/groupCategories.ts
@@ -2,7 +2,7 @@ import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { Request, Response } from 'express';
 import * as db from '../db';
 import { eq } from 'drizzle-orm';
-import { canViewGroupCategory } from '../services/groupCategories';
+import { canViewGroupsInGroupCategory } from '../services/groupCategories';
 
 export function getGroupCategoriesHandler(dbPool: PostgresJsDatabase<typeof db>) {
   return async function (req: Request, res: Response) {
@@ -35,7 +35,7 @@ export function getGroupCategoriesGroupsHandler(dbPool: PostgresJsDatabase<typeo
       return res.status(400).json({ error: 'Group Category ID is required' });
     }
 
-    const canView = await canViewGroupCategory(dbPool, groupCategoryId);
+    const canView = await canViewGroupsInGroupCategory(dbPool, groupCategoryId);
 
     if (!canView) {
       return res

--- a/src/handlers/groups.ts
+++ b/src/handlers/groups.ts
@@ -2,6 +2,10 @@ import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { Request, Response } from 'express';
 import * as db from '../db';
 import { eq } from 'drizzle-orm';
+import { insertGroupsSchema } from '../types/groups';
+import { canCreateGroupInGroupCategory } from '../services/groupCategories';
+import { createSecretGroup } from '../services/groups';
+import { upsertUsersToGroups } from '../services/usersToGroups';
 /**
  * Retrieves all groups from the database.
  * @param dbPool The database connection pool.
@@ -27,5 +31,42 @@ export function getGroupRegistrationsHandler(dbPool: PostgresJsDatabase<typeof d
     });
 
     return res.json({ data: registrations });
+  };
+}
+
+export function createGroupHandler(dbPool: PostgresJsDatabase<typeof db>) {
+  return async function (req: Request, res: Response) {
+    const userId = req.session.userId;
+    const body = insertGroupsSchema.safeParse(req.body);
+
+    if (!body.success) {
+      return res.status(400).json({ errors: body.error.errors });
+    }
+
+    try {
+      const canCreateGroup = await canCreateGroupInGroupCategory(
+        dbPool,
+        body.data.groupCategoryId!,
+      );
+
+      if (!canCreateGroup) {
+        return res
+          .status(403)
+          .json({ error: 'You do not have permission to create a group in this category' });
+      }
+
+      const newGroupRows = await createSecretGroup(dbPool, body.data);
+
+      if (!newGroupRows || !newGroupRows[0]) {
+        return res.status(500).json({ error: 'An error occurred while creating the group' });
+      }
+
+      // assign user to new group
+      await upsertUsersToGroups(dbPool, userId, [newGroupRows[0].id]);
+
+      return res.json({ data: newGroupRows[0] });
+    } catch (error) {
+      return res.status(500).json({ error: 'An error occurred while creating the group' });
+    }
   };
 }

--- a/src/handlers/usersToGroups.ts
+++ b/src/handlers/usersToGroups.ts
@@ -1,0 +1,32 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { Request, Response } from 'express';
+import * as db from '../db';
+import { joinGroupsSchema } from '../types/usersToGroups';
+import { getSecretGroup } from '../services/groups';
+import { upsertUsersToGroups } from '../services/usersToGroups';
+
+export function joinGroupsHandler(dbPool: PostgresJsDatabase<typeof db>) {
+  return async (req: Request, res: Response) => {
+    const userId = req.session.userId;
+    const body = joinGroupsSchema.safeParse(req.body);
+
+    if (!body.success) {
+      return res.status(400).json({ errors: body.error.errors });
+    }
+
+    try {
+      const secretGroup = await getSecretGroup(dbPool, body.data.secret);
+
+      if (!secretGroup) {
+        return res.status(404).json({ error: 'Group not found' });
+      }
+
+      const userToGroup = await upsertUsersToGroups(dbPool, userId, [secretGroup.id]);
+
+      return res.json({ data: userToGroup });
+    } catch (e) {
+      console.error(e);
+      return res.status(500).json({ error: 'An error occurred while joining the group' });
+    }
+  };
+}

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -13,6 +13,7 @@ import { commentsRouter } from './comments';
 import { optionsRouter } from './options';
 import { votesRouter } from './votes';
 import { registrationsRouter } from './registrations';
+import { usersToGroupsRouter } from './usersToGroups';
 
 const router = express.Router();
 
@@ -57,6 +58,7 @@ export function apiRouter({
   router.use('/options', optionsRouter({ dbPool }));
   router.use('/group-categories', optionsRouter({ dbPool }));
   router.use('/registrations', registrationsRouter({ dbPool }));
+  router.use('/users-to-groups', usersToGroupsRouter({ dbPool }));
 
   return router;
 }

--- a/src/routers/groupCategories.ts
+++ b/src/routers/groupCategories.ts
@@ -2,13 +2,18 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { default as express } from 'express';
 import type * as db from '../db';
 import { isLoggedIn } from '../middleware/isLoggedIn';
-import { getGroupCategoriesHandler, getGroupCategoryHandler } from '../handlers/groupCategories';
+import {
+  getGroupCategoriesGroupsHandler,
+  getGroupCategoriesHandler,
+  getGroupCategoryHandler,
+} from '../handlers/groupCategories';
 
 const router = express.Router();
 
 export function groupCategoriesRouter({ dbPool }: { dbPool: PostgresJsDatabase<typeof db> }) {
   router.get('/', isLoggedIn(dbPool), getGroupCategoriesHandler(dbPool));
   router.get('/:id', isLoggedIn(dbPool), getGroupCategoryHandler(dbPool));
+  router.get('/:id/groups', isLoggedIn(dbPool), getGroupCategoriesGroupsHandler(dbPool));
 
   return router;
 }

--- a/src/routers/groups.ts
+++ b/src/routers/groups.ts
@@ -2,11 +2,17 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { default as express } from 'express';
 import type * as db from '../db';
 import { isLoggedIn } from '../middleware/isLoggedIn';
-import { getGroupRegistrationsHandler, getGroupsHandler } from '../handlers/groups';
+import {
+  createGroupHandler,
+  getGroupRegistrationsHandler,
+  getGroupsHandler,
+} from '../handlers/groups';
 const router = express.Router();
 
 export function groupsRouter({ dbPool }: { dbPool: PostgresJsDatabase<typeof db> }) {
   router.get('/', isLoggedIn(dbPool), getGroupsHandler(dbPool));
+  router.post('/', isLoggedIn(dbPool), createGroupHandler(dbPool));
   router.get('/:id/registrations', isLoggedIn(dbPool), getGroupRegistrationsHandler(dbPool));
+
   return router;
 }

--- a/src/routers/usersToGroups.ts
+++ b/src/routers/usersToGroups.ts
@@ -1,0 +1,11 @@
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { default as express } from 'express';
+import type * as db from '../db';
+import { isLoggedIn } from '../middleware/isLoggedIn';
+
+const router = express.Router();
+
+export function usersToGroupsRouter({ dbPool }: { dbPool: PostgresJsDatabase<typeof db> }) {
+  router.post('/', isLoggedIn(dbPool));
+  return router;
+}

--- a/src/routers/usersToGroups.ts
+++ b/src/routers/usersToGroups.ts
@@ -2,10 +2,11 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { default as express } from 'express';
 import type * as db from '../db';
 import { isLoggedIn } from '../middleware/isLoggedIn';
+import { joinGroupsHandler } from '../handlers/usersToGroups';
 
 const router = express.Router();
 
 export function usersToGroupsRouter({ dbPool }: { dbPool: PostgresJsDatabase<typeof db> }) {
-  router.post('/', isLoggedIn(dbPool));
+  router.post('/', isLoggedIn(dbPool), joinGroupsHandler(dbPool));
   return router;
 }

--- a/src/services/groupCategories.spec.ts
+++ b/src/services/groupCategories.spec.ts
@@ -1,0 +1,85 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import * as db from '../db';
+import { createDbPool } from '../utils/db/createDbPool';
+import { runMigrations } from '../utils/db/runMigrations';
+import { cleanup, seed } from '../utils/db/seed';
+import { canCreateGroupInGroupCategory, canViewGroupsInGroupCategory } from './groupCategories';
+import { eq } from 'drizzle-orm';
+
+const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
+
+describe('service: groupCategories', () => {
+  let dbPool: PostgresJsDatabase<typeof db>;
+  let dbConnection: postgres.Sql<NonNullable<unknown>>;
+  let groupCategory: db.GroupCategory | undefined;
+
+  beforeAll(async () => {
+    const initDb = createDbPool(DB_CONNECTION_URL, { max: 1 });
+    await runMigrations(DB_CONNECTION_URL);
+    dbPool = initDb.dbPool;
+    dbConnection = initDb.connection;
+    // seed
+    const { groupCategories } = await seed(dbPool);
+
+    groupCategory = groupCategories[0];
+  });
+
+  describe('check if user can create group in category:', function () {
+    test('default:', async function () {
+      if (!groupCategory) {
+        throw new Error('Group category not found');
+      }
+
+      const canCreate = await canCreateGroupInGroupCategory(dbPool, groupCategory.id);
+
+      expect(canCreate).toBe(false);
+    });
+
+    test('userCanCreate: true', async function () {
+      if (!groupCategory) {
+        throw new Error('Group category not found');
+      }
+
+      await dbPool
+        .update(db.groupCategories)
+        .set({ userCanCreate: true })
+        .where(eq(db.groupCategories.id, groupCategory.id));
+
+      const canCreate = await canCreateGroupInGroupCategory(dbPool, groupCategory.id);
+
+      expect(canCreate).toBe(true);
+    });
+  });
+
+  describe('check if user can view group category', function () {
+    test('default:', async function () {
+      if (!groupCategory) {
+        throw new Error('Group category not found');
+      }
+
+      const canView = await canViewGroupsInGroupCategory(dbPool, groupCategory.id);
+
+      expect(canView).toBe(false);
+    });
+    test('userCanView: true', async function () {
+      if (!groupCategory) {
+        throw new Error('Group category not found');
+      }
+
+      await dbPool
+        .update(db.groupCategories)
+        .set({ userCanView: true })
+        .where(eq(db.groupCategories.id, groupCategory.id));
+
+      const canView = await canViewGroupsInGroupCategory(dbPool, groupCategory.id);
+
+      expect(canView).toBe(true);
+    });
+  });
+
+  afterAll(async () => {
+    await cleanup(dbPool);
+    await dbConnection.end();
+  });
+});

--- a/src/services/groupCategories.ts
+++ b/src/services/groupCategories.ts
@@ -16,7 +16,7 @@ export async function canCreateGroupInGroupCategory(
   return groupCategory.userCanCreate;
 }
 
-export async function canViewGroupCategory(
+export async function canViewGroupsInGroupCategory(
   dbPool: PostgresJsDatabase<typeof db>,
   groupCategoryId: string,
 ) {

--- a/src/services/groupCategories.ts
+++ b/src/services/groupCategories.ts
@@ -1,0 +1,32 @@
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as db from '../db';
+
+export async function canCreateGroupInGroupCategory(
+  dbPool: PostgresJsDatabase<typeof db>,
+  groupCategoryId: string,
+) {
+  const groupCategory = await dbPool.query.groupCategories.findFirst({
+    where: (fields, { eq }) => eq(fields.id, groupCategoryId),
+  });
+
+  if (!groupCategory) {
+    return false;
+  }
+
+  return groupCategory.userCanCreate;
+}
+
+export async function canViewGroupCategory(
+  dbPool: PostgresJsDatabase<typeof db>,
+  groupCategoryId: string,
+) {
+  const groupCategory = await dbPool.query.groupCategories.findFirst({
+    where: (fields, { eq }) => eq(fields.id, groupCategoryId),
+  });
+
+  if (!groupCategory) {
+    return false;
+  }
+
+  return groupCategory.userCanView;
+}

--- a/src/services/groups.spec.ts
+++ b/src/services/groups.spec.ts
@@ -1,0 +1,65 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import * as db from '../db';
+import { createDbPool } from '../utils/db/createDbPool';
+import { runMigrations } from '../utils/db/runMigrations';
+import { cleanup } from '../utils/db/seed';
+import { createSecretGroup, generateSecret, getSecretGroup } from './groups';
+
+const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
+
+describe('service: groups', () => {
+  let dbPool: PostgresJsDatabase<typeof db>;
+  let dbConnection: postgres.Sql<NonNullable<unknown>>;
+
+  beforeAll(async () => {
+    const initDb = createDbPool(DB_CONNECTION_URL, { max: 1 });
+    await runMigrations(DB_CONNECTION_URL);
+    dbPool = initDb.dbPool;
+    dbConnection = initDb.connection;
+  });
+
+  test('generate secret:', async function () {
+    const secret = generateSecret();
+    expect(secret).toHaveLength(12);
+  });
+
+  test('generate multiple secrets:', async function () {
+    const secrets = Array.from({ length: 10 }, () => generateSecret());
+
+    expect(secrets).toHaveLength(10);
+    expect(secrets).toEqual(expect.arrayContaining(secrets));
+    // none should be the same
+    expect(new Set(secrets).size).toBe(secrets.length);
+  });
+
+  test('create a group:', async function () {
+    const rows = await createSecretGroup(dbPool, {
+      name: 'Test Group',
+      description: 'Test Description',
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.name).toBe('Test Group');
+    expect(rows[0]?.description).toBe('Test Description');
+    // secret should be generated
+    expect(rows[0]?.secret).toHaveLength(12);
+  });
+
+  test('get a group:', async function () {
+    const rows = await createSecretGroup(dbPool, {
+      name: 'Test Group',
+      description: 'Test Description',
+    });
+
+    const group = await getSecretGroup(dbPool, rows[0]?.secret ?? '');
+
+    expect(group?.name).toBe('Test Group');
+    expect(group?.description).toBe('Test Description');
+  });
+
+  afterAll(async () => {
+    await cleanup(dbPool);
+    await dbConnection.end();
+  });
+});

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -2,6 +2,8 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as db from '../db';
 import type { Request, Response } from 'express';
 import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { insertGroupsSchema } from '../types/groups';
 
 /**
  * Retrieves groups by a specified group Category ID.
@@ -68,3 +70,8 @@ export function getGroupsPerUserByCategoryId(dbPool: PostgresJsDatabase<typeof d
     }
   };
 }
+
+export function createGroup(
+  dbPool: PostgresJsDatabase<typeof db>,
+  body: z.infer<typeof insertGroupsSchema>,
+) {}

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -10,7 +10,7 @@ export function createSecretGroup(
 ) {
   const secret = generateSecret();
 
-  const group = dbPool
+  const rows = dbPool
     .insert(db.groups)
     .values({
       ...body,
@@ -18,7 +18,7 @@ export function createSecretGroup(
     })
     .returning();
 
-  return group;
+  return rows;
 }
 
 export function getSecretGroup(dbPool: PostgresJsDatabase<typeof db>, secret: string) {

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -1,77 +1,26 @@
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as db from '../db';
-import type { Request, Response } from 'express';
-import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { insertGroupsSchema } from '../types/groups';
+import { randomBytes } from 'crypto';
 
-/**
- * Retrieves groups by a specified group Category ID.
- * @param dbPool The database connection pool.
- * @returns An asynchronous function that handles the HTTP request and response.
- */
-export function getGroupsByCategoryId(dbPool: PostgresJsDatabase<typeof db>) {
-  return async function (req: Request, res: Response) {
-    const groupCategoryId = req.params.groupCategoryId;
-    if (!groupCategoryId) {
-      return res.status(400).json({ error: 'groupCategoryId parameter is missing' });
-    }
-    try {
-      const groupByCategoryId = await dbPool.query.groups.findMany({
-        where: eq(db.groups.groupCategoryId, groupCategoryId),
-      });
-      return res.json({ data: groupByCategoryId });
-    } catch (e) {
-      console.error('error getting groups by Category id ' + JSON.stringify(e));
-      return res.status(500).json({ error: 'internal server error' });
-    }
-  };
-}
-
-/**
- * Retrieves groups associated with a specific user filtered by a group Category ID.
- * @param dbPool The database connection pool.
- * @returns An asynchronous function that handles the HTTP request and response.
- */
-export function getGroupsPerUserByCategoryId(dbPool: PostgresJsDatabase<typeof db>) {
-  return async function (req: Request, res: Response) {
-    const paramsUserId = req.params.userId;
-    const userId = req.session.userId;
-    const groupCategoryId = req.params.groupCategoryId;
-
-    if (paramsUserId !== userId) {
-      return res.status(403).json({ errors: ['forbidden'] });
-    }
-    if (!groupCategoryId) {
-      return res.status(400).json({ error: 'groupCategoryId parameter is missing' });
-    }
-
-    try {
-      // Fetch all groups associated with the user
-      const userGroups = await dbPool.query.usersToGroups.findMany({
-        with: {
-          group: true,
-        },
-        where: eq(db.usersToGroups.userId, userId),
-      });
-
-      // Filter groups by groupCategoryId
-      const groupsWithCategoryId = userGroups.filter(
-        (group) => group.group.groupCategoryId === groupCategoryId,
-      );
-
-      // Extract the group objects
-      const out = groupsWithCategoryId.map((r) => r.group);
-
-      return res.json({ data: out });
-    } catch (e) {
-      console.log('error getting groups per user by Category id ' + JSON.stringify(e));
-      return res.status(500).json({ error: 'internal server error' });
-    }
-  };
-}
-
-export function createGroup(
+export function createSecretGroup(
   dbPool: PostgresJsDatabase<typeof db>,
   body: z.infer<typeof insertGroupsSchema>,
-) {}
+) {
+  const secret = generateSecret();
+
+  const group = dbPool
+    .insert(db.groups)
+    .values({
+      ...body,
+      secret,
+    })
+    .returning();
+
+  return group;
+}
+
+export function generateSecret(): string {
+  return randomBytes(6).toString('hex');
+}

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -21,6 +21,14 @@ export function createSecretGroup(
   return group;
 }
 
+export function getSecretGroup(dbPool: PostgresJsDatabase<typeof db>, secret: string) {
+  const group = dbPool.query.groups.findFirst({
+    where: (fields, { eq }) => eq(fields.secret, secret),
+  });
+
+  return group;
+}
+
 export function generateSecret(): string {
   return randomBytes(6).toString('hex');
 }

--- a/src/types/groups.ts
+++ b/src/types/groups.ts
@@ -3,7 +3,7 @@ import { groups } from '../db';
 import { z } from 'zod';
 
 export const insertGroupsSchema = createInsertSchema(groups, {
-  groupCategoryId: z.string(),
+  groupCategoryId: z.string().trim().min(1),
 }).omit({
   createdAt: true,
   updatedAt: true,

--- a/src/types/groups.ts
+++ b/src/types/groups.ts
@@ -1,0 +1,12 @@
+import { createInsertSchema } from 'drizzle-zod';
+import { groups } from '../db';
+import { z } from 'zod';
+
+export const insertGroupsSchema = createInsertSchema(groups, {
+  groupCategoryId: z.string(),
+}).omit({
+  createdAt: true,
+  updatedAt: true,
+  secret: true,
+  id: true,
+});

--- a/src/types/usersToGroups.ts
+++ b/src/types/usersToGroups.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const joinGroupsSchema = z.object({
+  secret: z.string().min(1),
+});


### PR DESCRIPTION
## overview
this pr includes the flow for secret code authentication for groups

### db changes
- added user_can_view and user_can_create on a group category level, the goal behind this is to be able to distinguish our flows on frontend and adding an extra layer of security. For example, for joining a polize group we would set `view:true` and `create:false` and for secret group authentication it would be switched around to `create:true` and `view:false`
- added secret column to groups and made the secret unique

### endpoints
- GET group-categories/:id/groups: allows users to get a list of groups if authorization is correct
- POST groups/: creates a group with a secret and assigns user to group
- POST users-to-groups/: joins a group with a secret value passed through the payload

### edge cases
there is an edge case where a user can create groups and join groups if he knows the secret and is not accepted in the registration. i think this is not something that we will encounter but is possible and could be improved