### PR TITLE
Remove the handling of null values 

### DIFF
--- a/src/handlers/groups.ts
+++ b/src/handlers/groups.ts
@@ -1,24 +1,11 @@
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { Request, Response } from 'express';
 import * as db from '../db';
-import { eq, isNull } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { insertGroupsSchema } from '../types/groups';
 import { canCreateGroupInGroupCategory } from '../services/groupCategories';
 import { createSecretGroup } from '../services/groups';
 import { upsertUsersToGroups } from '../services/usersToGroups';
-/**
- * Retrieves all groups from the database.
- * @param dbPool The database connection pool.
- * @returns An asynchronous function that handles the HTTP request and response.
- */
-export function getGroupsHandler(dbPool: PostgresJsDatabase<typeof db>) {
-  return async function (req: Request, res: Response) {
-    const groups = await dbPool.query.groups.findMany({
-      where: isNull(db.groups.groupCategoryId),
-    });
-    return res.json({ data: groups });
-  };
-}
 
 export function getGroupRegistrationsHandler(dbPool: PostgresJsDatabase<typeof db>) {
   return async function (req: Request, res: Response) {

--- a/src/services/statistics.spec.ts
+++ b/src/services/statistics.spec.ts
@@ -31,7 +31,7 @@ describe('service: statistics', () => {
     questionOption = questionOptions[0];
     forumQuestion = forumQuestions[0];
     user = users[0];
-    otherUser = users[2];
+    otherUser = users[1];
     userTestData = {
       numOfVotes: 4,
       optionId: questionOption?.id ?? '',

--- a/src/services/votes.spec.ts
+++ b/src/services/votes.spec.ts
@@ -33,6 +33,7 @@ describe('service: votes', () => {
   let otherForumQuestion: db.ForumQuestion | undefined;
   let groupCategory: db.GroupCategory | undefined;
   let otherGroupCategory: db.GroupCategory | undefined;
+  let unrelatedGroupCategory: db.GroupCategory | undefined;
   let user: db.User | undefined;
   let secondUser: db.User | undefined;
   let thirdUser: db.User | undefined;
@@ -50,6 +51,7 @@ describe('service: votes', () => {
     otherForumQuestion = forumQuestions[1];
     groupCategory = groupCategories[0];
     otherGroupCategory = groupCategories[1];
+    unrelatedGroupCategory = groupCategories[2];
     user = users[0];
     secondUser = users[1];
     thirdUser = users[2];
@@ -209,10 +211,24 @@ describe('service: votes', () => {
   });
 
   test('only return groups for users who voted for the option', async () => {
-    // Get vote data required for groups
     const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
     const votesDictionary = await numOfVotesDictionary(voteArray);
     const groups = await groupsDictionary(dbPool, votesDictionary, [groupCategory!.id]);
+
+    expect(groups).toBeDefined();
+    expect(groups['unexpectedKey']).toBeUndefined();
+    expect(typeof groups).toBe('object');
+    expect(Object.keys(groups).length).toEqual(1);
+    expect(groups[Object.keys(groups)[0]!]!.length).toEqual(2);
+  });
+
+  test('only return groups for users who voted for the option with two elidgible group categories', async () => {
+    const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
+    const votesDictionary = await numOfVotesDictionary(voteArray);
+    const groups = await groupsDictionary(dbPool, votesDictionary, [
+      groupCategory!.id,
+      otherGroupCategory!.id,
+    ]);
 
     expect(groups).toBeDefined();
     expect(groups['unexpectedKey']).toBeUndefined();
@@ -225,22 +241,9 @@ describe('service: votes', () => {
     // Get vote data required for groups
     const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
     const votesDictionary = await numOfVotesDictionary(voteArray);
-    const groups = await groupsDictionary(dbPool, votesDictionary, [otherGroupCategory!.id]);
-
-    expect(groups).toBeDefined();
-    expect(groups['unexpectedKey']).toBeUndefined();
-    expect(typeof groups).toBe('object');
-    expect(Object.keys(groups).length).toEqual(1);
-    expect(groups[Object.keys(groups)[0]!]!.length).toEqual(2);
-  });
-
-  test('only return baseline groups when no addtional group category gets provided', async () => {
-    // Get vote data required for groups
-    const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
-    const votesDictionary = await numOfVotesDictionary(voteArray);
-
     const groups = await groupsDictionary(dbPool, votesDictionary, [
-      '00000000-0000-0000-0000-000000000000',
+      groupCategory!.id,
+      unrelatedGroupCategory!.id,
     ]);
 
     expect(groups).toBeDefined();

--- a/src/services/votes.spec.ts
+++ b/src/services/votes.spec.ts
@@ -200,13 +200,12 @@ describe('service: votes', () => {
     });
   });
 
-  test('that query group categories returns an empty array if their are no group categories for a specific question', async () => {
-    // Get vote data required for groups
+  test('that query group categories returns an empty array if their are no group categories specified for a specific question', async () => {
     const groupCategoriesIdArray = await queryGroupCategories(dbPool, otherForumQuestion!.id);
     expect(groupCategoriesIdArray).toBeDefined();
-    expect(groupCategoriesIdArray.length).toBe(1);
+    expect(groupCategoriesIdArray.length).toBe(0);
     expect(Array.isArray(groupCategoriesIdArray)).toBe(true);
-    expect(groupCategoriesIdArray).toEqual(['00000000-0000-0000-0000-000000000000']);
+    expect(groupCategoriesIdArray).toEqual([]);
   });
 
   test('only return groups for users who voted for the option', async () => {

--- a/src/services/votes.spec.ts
+++ b/src/services/votes.spec.ts
@@ -218,38 +218,38 @@ describe('service: votes', () => {
     expect(groups).toBeDefined();
     expect(groups['unexpectedKey']).toBeUndefined();
     expect(typeof groups).toBe('object');
+    expect(Object.keys(groups).length).toEqual(2);
+    expect(groups[Object.keys(groups)[0]!]!.length).toEqual(2);
+  });
+
+  test('only return baseline groups for users who voted for the option as non of the users is in the additional group category', async () => {
+    // Get vote data required for groups
+    const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
+    const votesDictionary = await numOfVotesDictionary(voteArray);
+    const groups = await groupsDictionary(dbPool, votesDictionary, [otherGroupCategory!.id]);
+
+    expect(groups).toBeDefined();
+    expect(groups['unexpectedKey']).toBeUndefined();
+    expect(typeof groups).toBe('object');
     expect(Object.keys(groups).length).toEqual(1);
     expect(groups[Object.keys(groups)[0]!]!.length).toEqual(2);
   });
 
-  // test('only return baseline groups for users who voted for the option as non of the users is in the additional group category', async () => {
-  //   // Get vote data required for groups
-  //   const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
-  //   const votesDictionary = await numOfVotesDictionary(voteArray);
-  //   const groups = await groupsDictionary(dbPool, votesDictionary, [otherGroupCategory!.id]);
+  test('only return baseline groups when no addtional group category gets provided', async () => {
+    // Get vote data required for groups
+    const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
+    const votesDictionary = await numOfVotesDictionary(voteArray);
 
-  //   expect(groups).toBeDefined();
-  //   expect(groups['unexpectedKey']).toBeUndefined();
-  //   expect(typeof groups).toBe('object');
-  //   expect(Object.keys(groups).length).toEqual(1);
-  //   expect(groups[Object.keys(groups)[0]!]!.length).toEqual(2);
-  // });
+    const groups = await groupsDictionary(dbPool, votesDictionary, [
+      '00000000-0000-0000-0000-000000000000',
+    ]);
 
-  // test('only return baseline groups when no addtional group category gets provided', async () => {
-  //   // Get vote data required for groups
-  //   const voteArray = await queryVoteData(dbPool, questionOption?.id ?? '');
-  //   const votesDictionary = await numOfVotesDictionary(voteArray);
-
-  //   const groups = await groupsDictionary(dbPool, votesDictionary, [
-  //     '00000000-0000-0000-0000-000000000000',
-  //   ]);
-
-  //   expect(groups).toBeDefined();
-  //   expect(groups['unexpectedKey']).toBeUndefined();
-  //   expect(typeof groups).toBe('object');
-  //   expect(Object.keys(groups).length).toEqual(1);
-  //   expect(groups[Object.keys(groups)[0]!]!.length).toEqual(2);
-  // });
+    expect(groups).toBeDefined();
+    expect(groups['unexpectedKey']).toBeUndefined();
+    expect(typeof groups).toBe('object');
+    expect(Object.keys(groups).length).toEqual(1);
+    expect(groups[Object.keys(groups)[0]!]!.length).toEqual(2);
+  });
 
   test('should calculate the plural score correctly', () => {
     // Mock groups dictionary

--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -89,14 +89,12 @@ export async function queryGroupCategories(
     .from(db.questionsToGroupCategories)
     .where(eq(db.questionsToGroupCategories.questionId, questionId));
 
-  // Need to due this adjustment because currently group_category_id is nullable due to affiliations having no label.
-  const groupCategoryIds = groupCategories
-    .map((category) => category.groupCategoryId)
-    .filter((id) => id !== null) as string[];
+  // Need to due this adjustment because currently groupCategoryId is nullable in the datatable definition.
+  const groupCategoryIds: string[] = groupCategories.map((category) => category.groupCategoryId!);
 
-  // Returning dummy uuid if there are no group categories found
   if (groupCategoryIds.length === 0) {
-    return ['00000000-0000-0000-0000-000000000000'];
+    console.error('Group Category ID is Missing');
+    return [];
   }
 
   return groupCategoryIds;
@@ -120,9 +118,7 @@ export async function groupsDictionary(
       WHERE user_id IN (${Object.keys(numOfVotesDictionary)
         .map((id) => `'${id}'`)
         .join(', ')})
-      AND (group_category_id IN (${groupCategories
-        .map((category) => `'${category}'`)
-        .join(', ')}) OR group_category_id IS NULL)
+      AND group_category_id IN (${groupCategories.map((category) => `'${category}'`).join(', ')})
       GROUP BY group_id
     `),
   );

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -9,7 +9,12 @@ async function seed(dbPool: PostgresJsDatabase<typeof db>) {
   const forumQuestions = await createForumQuestions(dbPool, cycles[0]?.id);
   const questionOptions = await createQuestionOptions(dbPool, forumQuestions[0]?.id);
   const groupCategories = await createGroupCategories(dbPool, events[0]?.id);
-  const groups = await createGroups(dbPool, groupCategories[0]?.id, groupCategories[1]?.id);
+  const groups = await createGroups(
+    dbPool,
+    groupCategories[0]?.id,
+    groupCategories[1]?.id,
+    groupCategories[2]?.id,
+  );
   const users = await createUsers(dbPool);
   const usersToGroups = await createUsersToGroups(
     dbPool,
@@ -167,6 +172,16 @@ async function createGroupCategories(dbPool: PostgresJsDatabase<typeof db>, even
         userCanView: true,
       },
       {
+        name: 'category A',
+        eventId: eventId,
+        userCanView: true,
+      },
+      {
+        name: 'category B',
+        eventId: eventId,
+        userCanView: true,
+      },
+      {
         name: 'secrets',
         eventId: eventId,
         userCanCreate: true,
@@ -177,26 +192,28 @@ async function createGroupCategories(dbPool: PostgresJsDatabase<typeof db>, even
 
 async function createGroups(
   dbPool: PostgresJsDatabase<typeof db>,
-  groupIdOne?: string,
-  groupIdTwo?: string,
+  baselineCategory?: string,
+  categoryOne?: string,
+  categoryTwo?: string,
 ) {
   return dbPool
     .insert(db.groups)
     .values([
       {
         name: randCompanyName(),
-        groupCategoryId: groupIdOne,
+        groupCategoryId: baselineCategory,
       },
       {
         name: randCompanyName(),
-        groupCategoryId: groupIdOne,
+        groupCategoryId: categoryOne,
       },
       {
         name: randCompanyName(),
-        groupCategoryId: groupIdTwo,
+        groupCategoryId: categoryOne,
       },
       {
         name: randCompanyName(),
+        groupCategoryId: categoryTwo,
       },
     ])
     .returning();
@@ -227,8 +244,8 @@ async function createUsersToGroups(
   userIds.forEach((userId) => {
     usersToGroups.push({
       userId,
-      groupId: groupIds[3]!,
-      groupCategoryId: undefined, // udefined because currently affiliation does not have a group category id
+      groupId: groupIds[0]!,
+      groupCategoryId: groupCategoryId,
     });
   });
 

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -21,6 +21,7 @@ async function seed(dbPool: PostgresJsDatabase<typeof db>) {
     users.map((u) => u.id!),
     groups.map((g) => g.id!),
     groupCategories[0]!.id,
+    groupCategories[1]!.id,
   );
   const questionsToGroupCategories = await createQuestionsToGroupCategories(
     dbPool,
@@ -231,13 +232,14 @@ async function createUsersToGroups(
   dbPool: PostgresJsDatabase<typeof db>,
   userIds: string[],
   groupIds: string[],
-  groupCategoryId: string | undefined,
+  baselineGroupCategory: string | undefined,
+  otherGroupCategory: string | undefined,
 ) {
   // assign users to groups
   const usersToGroups = userIds.map((userId, index) => ({
     userId,
-    groupId: index < 2 ? groupIds[0]! : groupIds[1]!,
-    groupCategoryId,
+    groupId: index < 2 ? groupIds[1]! : groupIds[2]!,
+    groupCategoryId: otherGroupCategory,
   }));
 
   // Add baseline group for each user (i.e. each user must be assigned to at least one group at all times)
@@ -245,7 +247,7 @@ async function createUsersToGroups(
     usersToGroups.push({
       userId,
       groupId: groupIds[0]!,
-      groupCategoryId: groupCategoryId,
+      groupCategoryId: baselineGroupCategory,
     });
   });
 

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -195,6 +195,9 @@ async function createGroups(
         name: randCompanyName(),
         groupCategoryId: groupIdTwo,
       },
+      {
+        name: randCompanyName(),
+      },
     ])
     .returning();
 }
@@ -211,7 +214,7 @@ async function createUsersToGroups(
   dbPool: PostgresJsDatabase<typeof db>,
   userIds: string[],
   groupIds: string[],
-  groupCategoryId: string,
+  groupCategoryId: string | undefined,
 ) {
   // assign users to groups
   const usersToGroups = userIds.map((userId, index) => ({
@@ -219,6 +222,15 @@ async function createUsersToGroups(
     groupId: index < 2 ? groupIds[0]! : groupIds[1]!,
     groupCategoryId,
   }));
+
+  // Add baseline group for each user (i.e. each user must be assigned to at least one group at all times)
+  userIds.forEach((userId) => {
+    usersToGroups.push({
+      userId,
+      groupId: groupIds[3]!,
+      groupCategoryId: undefined, // udefined because currently affiliation does not have a group category id
+    });
+  });
 
   return dbPool.insert(db.usersToGroups).values(usersToGroups).returning();
 }


### PR DESCRIPTION
**Note**: Merging of this PR requires that all `groupCategoryId`'s in staging and production (required for merge from develop to main) are updated in the `groups` and `usersToGroups` table. 

This PR includes the fix for #327 and simpliefies the services described in #300 