### PR TITLE
Seed a secret group

### DIFF
--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -14,6 +14,7 @@ async function seed(dbPool: PostgresJsDatabase<typeof db>) {
     groupCategories[0]?.id,
     groupCategories[1]?.id,
     groupCategories[2]?.id,
+    groupCategories[3]?.id,
   );
   const users = await createUsers(dbPool);
   const usersToGroups = await createUsersToGroups(
@@ -196,6 +197,7 @@ async function createGroups(
   baselineCategory?: string,
   categoryOne?: string,
   categoryTwo?: string,
+  secretCategory?: string,
 ) {
   return dbPool
     .insert(db.groups)
@@ -215,6 +217,10 @@ async function createGroups(
       {
         name: randCompanyName(),
         groupCategoryId: categoryTwo,
+      },
+      {
+        name: randCompanyName(),
+        groupCategoryId: secretCategory,
       },
     ])
     .returning();


### PR DESCRIPTION
Thi PR adds the functionality to the `seed` to seed a group with the `groupCategoryId` of the `secrets` group category. This allows us to test the research group functionality locally.