### PR TITLE
Limit one registration per group

### DIFF
--- a/src/handlers/registrations.ts
+++ b/src/handlers/registrations.ts
@@ -56,11 +56,12 @@ export function saveRegistrationHandler(dbPool: PostgresJsDatabase<typeof db>) {
       return res.status(400).json({ errors: missingRequiredFields });
     }
 
-    const canRegisterGroup = await validateCreateRegistrationPermissions(
+    const canRegisterGroup = await validateCreateRegistrationPermissions({
       dbPool,
       userId,
-      body.data.groupId,
-    );
+      eventId: body.data.eventId,
+      groupId: body.data.groupId,
+    });
 
     if (!canRegisterGroup) {
       return res.status(400).json({ errors: ['Cannot register for this group'] });

--- a/src/handlers/registrations.ts
+++ b/src/handlers/registrations.ts
@@ -6,7 +6,8 @@ import { validateRequiredRegistrationFields } from '../services/registrationFiel
 import {
   saveRegistration,
   updateRegistration,
-  validateGroupRegistration,
+  validateCreateRegistrationPermissions,
+  validateUpdateRegistrationPermissions,
 } from '../services/registrations';
 import { and, eq } from 'drizzle-orm';
 
@@ -55,7 +56,11 @@ export function saveRegistrationHandler(dbPool: PostgresJsDatabase<typeof db>) {
       return res.status(400).json({ errors: missingRequiredFields });
     }
 
-    const canRegisterGroup = await validateGroupRegistration(dbPool, userId, body.data.groupId);
+    const canRegisterGroup = await validateCreateRegistrationPermissions(
+      dbPool,
+      userId,
+      body.data.groupId,
+    );
 
     if (!canRegisterGroup) {
       return res.status(400).json({ errors: ['Cannot register for this group'] });
@@ -91,6 +96,17 @@ export function updateRegistrationHandler(dbPool: PostgresJsDatabase<typeof db>)
 
     if (missingRequiredFields.length > 0) {
       return res.status(400).json({ errors: missingRequiredFields });
+    }
+
+    const canUpdateRegistration = await validateUpdateRegistrationPermissions({
+      dbPool,
+      registrationId,
+      userId,
+      groupId: body.data.groupId,
+    });
+
+    if (!canUpdateRegistration) {
+      return res.status(400).json({ errors: ['Cannot update this registration'] });
     }
 
     try {

--- a/src/handlers/registrations.ts
+++ b/src/handlers/registrations.ts
@@ -3,7 +3,11 @@ import type { Request, Response } from 'express';
 import * as db from '../db';
 import { insertRegistrationSchema } from '../types';
 import { validateRequiredRegistrationFields } from '../services/registrationFields';
-import { saveRegistration, updateRegistration } from '../services/registrations';
+import {
+  saveRegistration,
+  updateRegistration,
+  validateGroupRegistration,
+} from '../services/registrations';
 import { and, eq } from 'drizzle-orm';
 
 export function getRegistrationDataHandler(dbPool: PostgresJsDatabase<typeof db>) {
@@ -49,6 +53,12 @@ export function saveRegistrationHandler(dbPool: PostgresJsDatabase<typeof db>) {
 
     if (missingRequiredFields.length > 0) {
       return res.status(400).json({ errors: missingRequiredFields });
+    }
+
+    const canRegisterGroup = await validateGroupRegistration(dbPool, userId, body.data.groupId);
+
+    if (!canRegisterGroup) {
+      return res.status(400).json({ errors: ['Cannot register for this group'] });
     }
 
     try {

--- a/src/services/registrations.ts
+++ b/src/services/registrations.ts
@@ -21,6 +21,15 @@ export async function saveRegistration(
     if (!userGroup) {
       throw new Error('user is not in group');
     }
+
+    // limit one registration per group
+    const existingRegistration = await dbPool.query.registrations.findFirst({
+      where: and(eq(db.registrations.userId, userId), eq(db.registrations.groupId, data.groupId)),
+    });
+
+    if (existingRegistration) {
+      throw new Error('registration already exists for group');
+    }
   }
 
   const newRegistration = await createRegistrationInDB(dbPool, data);

--- a/src/services/registrations.ts
+++ b/src/services/registrations.ts
@@ -8,11 +8,17 @@ import {
   upsertQuestionOptionFromRegistrationData,
 } from './registrationData';
 
-export async function validateCreateRegistrationPermissions(
-  dbPool: PostgresJsDatabase<typeof db>,
-  userId: string,
-  groupId?: string | null,
-) {
+export async function validateCreateRegistrationPermissions({
+  dbPool,
+  userId,
+  groupId,
+  eventId,
+}: {
+  dbPool: PostgresJsDatabase<typeof db>;
+  userId: string;
+  eventId: string;
+  groupId?: string | null;
+}) {
   if (groupId) {
     const userGroup = dbPool.query.usersToGroups.findFirst({
       where: and(eq(db.usersToGroups.userId, userId), eq(db.usersToGroups.groupId, groupId)),
@@ -22,9 +28,9 @@ export async function validateCreateRegistrationPermissions(
       return false;
     }
 
-    // limit one registration per group
+    // limit one registration per group per event
     const existingRegistration = await dbPool.query.registrations.findFirst({
-      where: and(eq(db.registrations.userId, userId), eq(db.registrations.groupId, groupId)),
+      where: and(eq(db.registrations.eventId, eventId), eq(db.registrations.groupId, groupId)),
     });
 
     if (existingRegistration) {


### PR DESCRIPTION
closes https://github.com/lexicongovernance/pluraltools-backend/issues/336

## overview
- will only allow only one registration per group
- adds authorization to updating an event so only the leader can do it