### PR TITLE
adds better validation for fields and register field options in seed

### DIFF
--- a/src/services/registrationFields.ts
+++ b/src/services/registrationFields.ts
@@ -39,9 +39,23 @@ export async function validateRequiredRegistrationFields({
   }
 
   // loop through required fields and check if they are filled
-  const missingFields = requiredFields.filter(
-    (field) => !data.registrationData.some((data) => data.registrationFieldId === field.id),
-  );
+  const missingFields = requiredFields.filter((field) => {
+    const registrationField = data.registrationData.find(
+      (data) => data.registrationFieldId === field.id,
+    );
+
+    // if field is not found in registration data, it is missing
+    if (!registrationField) {
+      return true;
+    }
+
+    // if field is found but value is empty, it is missing
+    if (!registrationField.value) {
+      return true;
+    }
+
+    return false;
+  });
 
   return missingFields.map((field) => ({
     field: field.name,

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -6,6 +6,10 @@ async function seed(dbPool: PostgresJsDatabase<typeof db>) {
   const events = await createEvent(dbPool);
   const cycles = await createCycle(dbPool, events[0]?.id);
   const registrationFields = await createRegistrationFields(dbPool, events[0]?.id);
+  const registrationFieldOptions = await createRegistrationFieldOptions(
+    dbPool,
+    registrationFields[3]?.id,
+  );
   const forumQuestions = await createForumQuestions(dbPool, cycles[0]?.id);
   const questionOptions = await createQuestionOptions(dbPool, forumQuestions[0]?.id);
   const groupCategories = await createGroupCategories(dbPool, events[0]?.id);
@@ -42,6 +46,7 @@ async function seed(dbPool: PostgresJsDatabase<typeof db>) {
     usersToGroups,
     registrationFields,
     questionsToGroupCategories,
+    registrationFieldOptions,
   };
 }
 
@@ -51,6 +56,7 @@ async function cleanup(dbPool: PostgresJsDatabase<typeof db>) {
   await dbPool.delete(db.federatedCredentials);
   await dbPool.delete(db.questionOptions);
   await dbPool.delete(db.registrationData);
+  await dbPool.delete(db.registrationFieldOptions);
   await dbPool.delete(db.registrationFields);
   await dbPool.delete(db.registrations);
   await dbPool.delete(db.usersToGroups);
@@ -103,6 +109,36 @@ async function createRegistrationFields(dbPool: PostgresJsDatabase<typeof db>, e
         type: 'TEXT',
         required: false,
         eventId,
+      },
+      {
+        name: 'select field',
+        type: 'SELECT',
+        required: true,
+        eventId,
+        forUser: true,
+      },
+    ])
+    .returning();
+}
+
+async function createRegistrationFieldOptions(
+  dbPool: PostgresJsDatabase<typeof db>,
+  registrationFieldId?: string,
+) {
+  if (registrationFieldId === undefined) {
+    throw new Error('Registration Field ID is undefined.');
+  }
+
+  return dbPool
+    .insert(db.registrationFieldOptions)
+    .values([
+      {
+        registrationFieldId,
+        value: 'Option A',
+      },
+      {
+        registrationFieldId,
+        value: 'Option B',
       },
     ])
     .returning();

--- a/src/utils/db/seed.ts
+++ b/src/utils/db/seed.ts
@@ -113,7 +113,7 @@ async function createRegistrationFields(dbPool: PostgresJsDatabase<typeof db>, e
       {
         name: 'select field',
         type: 'SELECT',
-        required: true,
+        required: false,
         eventId,
         forUser: true,
       },


### PR DESCRIPTION
## overview
stops frontend from sending empty string `""` as a valid input

adds select options to registration so it can be tested quicker