### PR TITLE
Avoid vote score exposure through the api

### DIFF
--- a/src/handlers/options.ts
+++ b/src/handlers/options.ts
@@ -12,9 +12,20 @@ export function getOptionHandler(dbPool: PostgresJsDatabase<typeof db>) {
       return res.status(400).json({ error: 'Missing optionId' });
     }
 
-    const option = await dbPool.query.questionOptions.findFirst({
-      where: eq(db.questionOptions.id, optionId),
-    });
+    const option = await dbPool
+      .select({
+        Id: db.questionOptions.id,
+        userId: db.questionOptions.userId,
+        registrationId: db.questionOptions.registrationId,
+        questionId: db.questionOptions.questionId,
+        optionTitle: db.questionOptions.optionTitle,
+        optionSubTitle: db.questionOptions.optionSubTitle,
+        accepted: db.questionOptions.accepted,
+        createdAt: db.questionOptions.createdAt,
+        updatedAt: db.questionOptions.updatedAt,
+      })
+      .from(db.questionOptions)
+      .where(eq(db.questionOptions.id, optionId));
 
     return res.json({ data: option });
   };

--- a/src/handlers/options.ts
+++ b/src/handlers/options.ts
@@ -14,7 +14,7 @@ export function getOptionHandler(dbPool: PostgresJsDatabase<typeof db>) {
 
     const option = await dbPool
       .select({
-        Id: db.questionOptions.id,
+        id: db.questionOptions.id,
         userId: db.questionOptions.userId,
         registrationId: db.questionOptions.registrationId,
         questionId: db.questionOptions.questionId,


### PR DESCRIPTION
This PR modifies the `getOptionHandler` by excluding the vote score from being queries. Therefore, the vote score will not show up anymore as part of the network request in addition to not displaying it in the UI. However, merging this PR requires to update the option type in the frontend. 