### PR TITLE
Fix get option users

### DIFF
--- a/src/handlers/options.ts
+++ b/src/handlers/options.ts
@@ -76,7 +76,7 @@ export function getOptionUsersHandler(dbPool: PostgresJsDatabase<typeof db>) {
       // Send response
       return res.status(200).json({ data: responseData });
     } catch (error) {
-      console.error('Error in getOptionAuthors:', error);
+      console.error('Error in getOptionUsers:', error);
       return res.status(500).json({ error: 'Internal Server Error' });
     }
   };


### PR DESCRIPTION
The `getOptionUsers` endpoint will now return the `userId` and user info of the option owner event though the option is not related to a secret group.