### PR TITLE
Fix return statement for join groups 

### DIFF
--- a/src/services/users-to-groups.ts
+++ b/src/services/users-to-groups.ts
@@ -25,7 +25,7 @@ export async function createUsersToGroups(
     throw new Error('User is already part of the group');
   }
 
-  await dbPool
+  return await dbPool
     .insert(db.usersToGroups)
     .values({ userId, groupId, groupCategoryId: group.groupCategoryId })
     .returning();


### PR DESCRIPTION
The PR includes a return statement to show the created usersToGroups relationship in the network request. Furthermore, the frontend sends an alert now indicating that the joining of the group was successfull. 