### PR TITLE
Only return group names and distinct groups for affiliations

### DIFF
--- a/src/services/statistics.spec.ts
+++ b/src/services/statistics.spec.ts
@@ -84,7 +84,7 @@ describe('service: statistics', () => {
         expect(optionStat?.distinctUsers).toEqual(2);
         expect(optionStat?.allocatedHearts).toEqual(8);
         expect(optionStat?.quadraticScore).toEqual('4');
-        expect(optionStat?.distinctGroups).toEqual(2);
+        expect(optionStat?.distinctGroups).toEqual(1);
         const listOfGroupNames = optionStat?.listOfGroupNames;
         // Check if the array is not empty
         expect(listOfGroupNames).toBeDefined();

--- a/src/services/statistics.ts
+++ b/src/services/statistics.ts
@@ -142,11 +142,19 @@ export async function executeResultQueries(
           ),
           
           /* Query distinct groups and group names by option id */
+
+          affiliation_category AS (
+            SELECT id, name 
+            FROM group_categories
+            WHERE name = 'affiliation'
+          ),
+
           user_group_name AS (
               SELECT users_to_groups."user_id", users_to_groups."group_id", groups."name" 
               FROM users_to_groups
               LEFT JOIN groups
               ON users_to_groups."group_id" = groups."id"
+              WHERE users_to_groups.group_category_id IN (SELECT id FROM affiliation_category)
           ),
           
           option_user AS (


### PR DESCRIPTION
This PR adds a subquery to filter groups by the affiliation group category id before calculating the `distinctGroups` and `groupNames` statistic. Therefore, only `affiliations` count towards computing these statistics and no other categories.