### PR TITLE
return relevant group for cycle

### DIFF
--- a/src/services/cycles.ts
+++ b/src/services/cycles.ts
@@ -51,8 +51,8 @@ export async function GetCycleById(dbPool: PostgresJsDatabase<typeof db>, cycleI
               firstName: option.user?.firstName,
               lastName: option.user?.lastName,
               // return a group if the user is in a group that is relevant to the cycle
-              group: option.user?.usersToGroups.find(
-                (userToGroup) => relevantCategories?.includes(userToGroup.groupCategoryId),
+              group: option.user?.usersToGroups.find((userToGroup) =>
+                relevantCategories?.includes(userToGroup.groupCategoryId),
               )?.group,
             },
             createdAt: option.createdAt,


### PR DESCRIPTION
closes https://github.com/lexicongovernance/pluraltools-backend/issues/391


## overview
in get cycle, we would return the a group with no specific filter. now we check that the group we return is relevant to the question and the plural score calculation. 