### PR TITLE
fix statistic endpoint

### DIFF
--- a/src/services/cycles.ts
+++ b/src/services/cycles.ts
@@ -51,8 +51,8 @@ export async function GetCycleById(dbPool: PostgresJsDatabase<typeof db>, cycleI
               firstName: option.user?.firstName,
               lastName: option.user?.lastName,
               // return a group if the user is in a group that is relevant to the cycle
-              group: option.user?.usersToGroups.find(
-                (userToGroup) => relevantCategories?.includes(userToGroup.groupCategoryId),
+              group: option.user?.usersToGroups.find((userToGroup) =>
+                relevantCategories?.includes(userToGroup.groupCategoryId),
               )?.group,
             },
             createdAt: option.createdAt,

--- a/src/services/cycles.ts
+++ b/src/services/cycles.ts
@@ -51,8 +51,8 @@ export async function GetCycleById(dbPool: PostgresJsDatabase<typeof db>, cycleI
               firstName: option.user?.firstName,
               lastName: option.user?.lastName,
               // return a group if the user is in a group that is relevant to the cycle
-              group: option.user?.usersToGroups.find((userToGroup) =>
-                relevantCategories?.includes(userToGroup.groupCategoryId),
+              group: option.user?.usersToGroups.find(
+                (userToGroup) => relevantCategories?.includes(userToGroup.groupCategoryId),
               )?.group,
             },
             createdAt: option.createdAt,

--- a/src/services/statistics.spec.ts
+++ b/src/services/statistics.spec.ts
@@ -61,6 +61,7 @@ describe('service: statistics', () => {
     expect(result.numProposals).toEqual(2);
     expect(result.sumNumOfHearts).toEqual(8);
     expect(result.numOfParticipants).toEqual(2);
+    expect(result.numOfGroups).toEqual(1);
 
     // Test option stats
     expect(result.optionStats).toBeDefined();

--- a/src/services/statistics.ts
+++ b/src/services/statistics.ts
@@ -82,11 +82,18 @@ export async function executeResultQueries(
               SELECT DISTINCT user_id
               FROM votes 
               WHERE question_id = '${forumQuestionId}'
+          ),
+
+          question_categories AS (
+            SELECT group_category_id
+            FROM questions_to_group_categories
+            WHERE question_id = '${forumQuestionId}'
           )
   
           SELECT count(DISTINCT group_id)::int AS "numOfGroups"
           FROM users_to_groups
           WHERE user_id IN (SELECT user_id FROM votes_users)
+          AND users_to_groups.group_category_id IN (SELECT group_category_id FROM question_categories)
           `),
       ),
 


### PR DESCRIPTION
This PR fixes the number of groups calculation. The overall number of groups statistic only considers groups relevant for the plurality score calculation. 